### PR TITLE
:bug: Remove symlinks to fix #11

### DIFF
--- a/packages/flex-plugin/bin/check-start
+++ b/packages/flex-plugin/bin/check-start
@@ -6,21 +6,38 @@ const { existsSync } = require('fs');
 const { join } = require('path');
 const chalk = require('chalk');
 const { stripIndent } = require('common-tags');
+const ncp = require('ncp').ncp;
+const { promisify } = require('util');
 
-const ERROR = chalk.bold.red('ERROR');
+(async () => {
+  const cp = promisify(ncp);
 
-const appConfigPath = join(process.cwd(), 'public', 'appConfig.js');
+  const ERROR = chalk.bold.red('ERROR');
 
-const appConfigExists = existsSync(appConfigPath);
-if (!appConfigExists) {
-  console.error(stripIndent`
+  const appConfigPath = join(process.cwd(), 'public', 'appConfig.js');
+
+  const appConfigExists = existsSync(appConfigPath);
+  if (!appConfigExists) {
+    console.error(stripIndent`
   ${ERROR} Could not find ${chalk.cyan('public/appConfig.js')}.
 
   Check your ${chalk.cyan('public/')} directory for ${chalk.cyan(
-    'appConfig.example.js'
-  )}, copy it to ${chalk.cyan(
-    'appConfig.js'
-  )} and modify your Account SID and Service Base URL.
+        'appConfig.example.js'
+      )}, copy it to ${chalk.cyan(
+        'appConfig.js'
+      )} and modify your Account SID and Service Base URL.
   `);
-  process.exit(1);
-}
+    process.exit(1);
+  }
+
+  const indexSourcePath = join(__dirname,'..', 'dev_assets', 'index.html');
+  const indexTargetPath = join(process.cwd(), 'public', 'index.html');
+  try {
+    await cp(indexSourcePath, indexTargetPath, { clobber: true });
+  } catch (err) {
+    console.log(err);
+    console.error(`${ERROR} Failed to copy index.html file into public/ directory`);
+  }
+})().catch(err => {
+  console.error(err);
+});

--- a/packages/flex-plugin/package.json
+++ b/packages/flex-plugin/package.json
@@ -37,6 +37,7 @@
   "gitHead": "ca02b3d214e6dfa4277b6b69cbbb178783004edf",
   "dependencies": {
     "chalk": "^2.4.1",
-    "common-tags": "^1.8.0"
+    "common-tags": "^1.8.0",
+    "ncp": "^2.0.0"
   }
 }

--- a/packages/react-app-rewire-flex-plugin/lib/index.js
+++ b/packages/react-app-rewire-flex-plugin/lib/index.js
@@ -8,16 +8,6 @@ const fs = require('fs');
 
 process.env.PORT = process.env.PORT || 8080;
 
-const indexHtmlSource = path.join('..', 'node_modules', 'flex-plugin', 'dev_assets', 'index.html');
-const indexHtmlTarget = path.join('public', 'index.html');
-try {
-  fs.symlinkSync(indexHtmlSource, indexHtmlTarget);
-} catch (err) {
-  if (err.code !== 'EEXIST') {
-    console.error(err);
-  }
-}
-
 function overrideWebpack(config, env) {
   //do stuff with the webpack config...
   const pkg = readPkg.sync();


### PR DESCRIPTION
Apparently symlinking is tough on Windows as it requires Admin privileges. 

So instead I'm copying the file (and override it if necessary) into the `public/` folder when `flex-check-start` is executed on `npm start`.