### PR TITLE
:sparkles: Fix typings and add jsDoc header 

### DIFF
--- a/packages/create-flex-plugin/package.json
+++ b/packages/create-flex-plugin/package.json
@@ -48,7 +48,7 @@
     "url": "https://github.com/twilio/flex-plugin-builder/issues"
   },
   "devDependencies": {
-    "@twilio/flex-ui": "^1.0.0",
+    "@twilio/flex-ui": "1.0.2",
     "flex-plugin": "^1.0.2"
   },
   "gitHead": "ca02b3d214e6dfa4277b6b69cbbb178783004edf"

--- a/packages/create-flex-plugin/src/create-flex-plugin.js
+++ b/packages/create-flex-plugin/src/create-flex-plugin.js
@@ -104,7 +104,7 @@ export default async function createFlexPlugin(config) {
 
   config.targetDirectory = path.join(process.cwd(), config.pluginFileName);
   config.flexSdkVersion = pkg.devDependencies['@twilio/flex-ui'];
-  config.flexPluginVersion = pkg.devDependencies['flex-plugin'];
+  config.flexPluginVersion = pkg.devDependencies['flex-plugin'].replace('^', '');
   config.pluginJsonContent = JSON.stringify(getPluginJsonContent(config), null, 2);
 
   const templateSpinner = ora('Creating project directory');

--- a/packages/create-flex-plugin/templates/src/DemoPlugin.js
+++ b/packages/create-flex-plugin/templates/src/DemoPlugin.js
@@ -2,12 +2,26 @@ import { FlexPlugin } from 'flex-plugin';
 import React from 'react';
 import CustomTaskListComponent from './CustomTaskListComponent';
 
-export default class {{pluginClassName}} extends FlexPlugin {
-  name = '{{pluginClassName}}';
+const PLUGIN_NAME = '{{pluginClassName}}';
 
+export default class {{pluginClassName}} extends FlexPlugin {
+  constructor() {
+    super(PLUGIN_NAME);
+  }
+
+  /**
+   * This code is run when your plugin is being started
+   * Use this to modify any UI components or attach to the actions framework
+   *
+   * @param flex { typeof import('@twilio/flex-ui') }
+   * @param manager { import('@twilio/flex-ui').Manager }
+   */
   init(flex, manager) {
-    flex.AgentDesktopView.Panel1.Content.add(<CustomTaskListComponent key="demo-component" />, {
-      sortOrder: -1,
-    });
+    flex.AgentDesktopView.Panel1.Content.add(
+      <CustomTaskListComponent key="demo-component" />,
+      {
+        sortOrder: -1,
+      }
+    );
   }
 }

--- a/packages/flex-plugin/package.json
+++ b/packages/flex-plugin/package.json
@@ -29,14 +29,17 @@
     "prepublish": "npm run build"
   },
   "devDependencies": {
+    "@twilio/flex-ui": "1.0.2",
     "@types/loglevel": "^1.5.3",
     "@types/node": "^10.11.0",
     "typescript": "^3.0.3"
   },
   "gitHead": "ca02b3d214e6dfa4277b6b69cbbb178783004edf",
   "dependencies": {
-    "@twilio/flex-ui": "1.0.2",
     "chalk": "^2.4.1",
     "common-tags": "^1.8.0"
+  },
+  "peerDependencies": {
+    "@twilio/flex-ui": "*"
   }
 }

--- a/packages/flex-plugin/package.json
+++ b/packages/flex-plugin/package.json
@@ -29,13 +29,13 @@
     "prepublish": "npm run build"
   },
   "devDependencies": {
-    "@twilio/flex-ui": "^1.0.2",
     "@types/loglevel": "^1.5.3",
     "@types/node": "^10.11.0",
     "typescript": "^3.0.3"
   },
   "gitHead": "ca02b3d214e6dfa4277b6b69cbbb178783004edf",
   "dependencies": {
+    "@twilio/flex-ui": "1.0.2",
     "chalk": "^2.4.1",
     "common-tags": "^1.8.0"
   }

--- a/packages/flex-plugin/package.json
+++ b/packages/flex-plugin/package.json
@@ -29,7 +29,7 @@
     "prepublish": "npm run build"
   },
   "devDependencies": {
-    "@twilio/flex-ui": "^1.0.0",
+    "@twilio/flex-ui": "^1.0.2",
     "@types/loglevel": "^1.5.3",
     "@types/node": "^10.11.0",
     "typescript": "^3.0.3"

--- a/packages/flex-plugin/src/flex-plugin.ts
+++ b/packages/flex-plugin/src/flex-plugin.ts
@@ -1,5 +1,7 @@
 import * as Flex from '@twilio/flex-ui';
 
+type FlexGlobal = typeof Flex;
+
 declare global {
   interface Window {
     serviceBaseUrl?: string;
@@ -17,13 +19,16 @@ declare const Twilio: {
   }
 }
 
-export interface FlexPlugin {
+export interface IFlexPlugin {
   name: string;
-  getName(): string;
-  init(flex: any, manager: Flex.ContactCenterManager): any;
+  init(flex: FlexGlobal, manager: Flex.Manager): void;
 }
 
-export class FlexPlugin implements FlexPlugin {
+export interface PluginConstructor<T> {
+  new (): T;
+}
+
+export abstract class FlexPlugin implements IFlexPlugin {
   public name: string;
 
   constructor(name: string) {
@@ -31,12 +36,10 @@ export class FlexPlugin implements FlexPlugin {
     console.log(`loading ${this.name} plugin`);
   }
 
-  public getName() {
-    return this.name;
-  }
+  abstract init(flex: FlexGlobal, manager: Flex.Manager): void;
 }
 
-export function loadPlugin(plugin: FlexPlugin) {
+export function loadPlugin<T extends FlexPlugin>(plugin: PluginConstructor<T>) {
   if (Twilio && Twilio.Flex && Twilio.Flex.Plugins) {
     Twilio.Flex.Plugins.init(plugin);
   } else {


### PR DESCRIPTION
This PR has a few things going on around typings:
1) This will pin the version that is being used in plugin projects to make sure it's always the same as the one that is actually being loaded in `index.html`
2) It adds JSDoc headers to the `init()` method in the plugin template to provide types and autocomplete even if the user is not using TypeScript
3) I restructured the types to fix the Type error in the load() function of the `flex-plugin` package