### PR TITLE
Bump flex-ui to 1.1.1

### DIFF
--- a/packages/create-flex-plugin/templates/package.json
+++ b/packages/create-flex-plugin/templates/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "flex-plugin": "{{flexPluginVersion}}",
-    "react": "^16.5.2",
-    "react-dom": "^16.5.2",
+    "react": "16.5.2",
+    "react-dom": "16.5.2",
     "react-scripts": "1.1.5"
   },
   "config-overrides-path": "node_modules/react-app-rewire-flex-plugin"

--- a/packages/flex-plugin/package.json
+++ b/packages/flex-plugin/package.json
@@ -29,7 +29,7 @@
     "prepublish": "npm run build"
   },
   "devDependencies": {
-    "@twilio/flex-ui": "1.1.0",
+    "@twilio/flex-ui": "1.1.1",
     "@types/loglevel": "^1.5.3",
     "@types/node": "^10.11.0",
     "typescript": "^3.0.3"


### PR DESCRIPTION
This inherits a pinning of React to 16.5.2 to address version mismatches moving forward in plugins leading to errors such as 

![image](https://user-images.githubusercontent.com/2159342/48216793-85f78680-e33a-11e8-88d3-8ce33eb8676a.png)
