### PR TITLE
Remove flex-ui and flex-plugin from devDependencies

### DIFF
--- a/packages/create-flex-plugin/package.json
+++ b/packages/create-flex-plugin/package.json
@@ -47,9 +47,5 @@
   "bugs": {
     "url": "https://github.com/twilio/flex-plugin-builder/issues"
   },
-  "devDependencies": {
-    "@twilio/flex-ui": "1.1.0",
-    "flex-plugin": "^1.1.0"
-  },
   "gitHead": "ca02b3d214e6dfa4277b6b69cbbb178783004edf"
 }

--- a/packages/create-flex-plugin/src/create-flex-plugin.js
+++ b/packages/create-flex-plugin/src/create-flex-plugin.js
@@ -103,22 +103,25 @@ export default async function createFlexPlugin(config) {
   config.runtimeUrl = config.runtimeUrl || 'http://localhost:8080';
 
   config.targetDirectory = path.join(process.cwd(), config.pluginFileName);
-  config.flexSdkVersion = pkg.devDependencies['@twilio/flex-ui'];
-  config.flexPluginVersion = pkg.devDependencies['flex-plugin'].replace('^', '');
+  config.flexSdkVersion = pkg.version;
+  config.flexPluginVersion = pkg.version;
   config.pluginJsonContent = JSON.stringify(getPluginJsonContent(config), null, 2);
 
   const templateSpinner = ora('Creating project directory');
   try {
     templateSpinner.start();
-    const createdFiles = await copyDir(
+
+    await copyDir(
       templatePath,
       config.targetDirectory,
       config
     );
+
     await moveFile(
       path.join(config.targetDirectory, 'src/DemoPlugin.js'),
       path.join(config.targetDirectory, `src/${config.pluginClassName}.js`)
     );
+
     templateSpinner.succeed();
   } catch (err) {
     templateSpinner.fail(err.message);


### PR DESCRIPTION
`@twilio/flex-ui` and `flex-plugin` are just used inside `create-flex-plugin`
for fetching the version number from the `package.json` file but never
directly consumed inside the project.