### PR TITLE
updated Readme for create-flex-plugin for not supporting yarn

### DIFF
--- a/packages/create-flex-plugin/README.md
+++ b/packages/create-flex-plugin/README.md
@@ -32,6 +32,8 @@ npm install -g create-flex-plugin
 create-flex-plugin plugin-demo
 ```
 
+We do not support `yarn` at the moment.
+
 ### Command line arguments:
 
 ```


### PR DESCRIPTION
Following the issue https://github.com/twilio/flex-plugin-builder/issues/2.

Since `yarn` doesn't support `bundledDependencies` at the moment. I am updating the readme suggesting we don't support `yarn`.