### PR TITLE
Fix login redirect issue

### DIFF
--- a/packages/flex-plugin/dev_assets/flex.js
+++ b/packages/flex-plugin/dev_assets/flex.js
@@ -2,6 +2,8 @@ const REDIRECT_KEY = 'LOCAL_FLEX_PLUGIN_LOGIN_REDIRECT';
 const FIRST_LOAD_KEY = 'LOCAL_FLEX_PLUGIN_FIRST_LOAD';
 
 function loadFlex() {
+  const localUrl = location.hostname;
+
   if (
     typeof appConfig === 'undefined' ||
     !appConfig.sso.accountSid ||
@@ -12,7 +14,7 @@ function loadFlex() {
     );
   } else {
     const loginUrl = `http://www.twilio.com/service-login/flex/${appConfig.sso.accountSid || accountSid}?localPort=${window.location.port}`
-    if (!localStorage.getItem(FIRST_LOAD_KEY)) {
+    if (!localStorage.getItem(FIRST_LOAD_KEY) && localUrl === 'flex.twilio.com') {
       localStorage.setItem(FIRST_LOAD_KEY, 'redirected');
       window.location.replace(loginUrl);
       return;


### PR DESCRIPTION
Reported in flex-community:
```
A little tip for anyone who has trouble logging in w/ SSO when testing plugins. The logic in 
`/node_modules/flex-plugin/dev_assets/flex.js` tries to send you from localhost to the Twilio login, not 
the SSO login. After the 3rd time of loading localhost you are sent to your SSO login, b/c the login in 
that script sets some stuff in localstorage... I added the line 
`localStorage.setItem("LOCAL_FLEX_PLUGIN_FIRST_LOAD", 'redirected');` in `plugin-{your-plugin}-
flex/public/index.html` which sets that same localStorage key before running `loadFlex()` -- and now 
when `npm start` refreshes the page, you're no longer fwd'ed to Twilio's login -- just SSO
```