### PR TITLE
Login redirect issue

### DIFF
--- a/packages/flex-plugin/dev_assets/flex.js
+++ b/packages/flex-plugin/dev_assets/flex.js
@@ -2,6 +2,10 @@ const REDIRECT_KEY = 'LOCAL_FLEX_PLUGIN_LOGIN_REDIRECT';
 const FIRST_LOAD_KEY = 'LOCAL_FLEX_PLUGIN_FIRST_LOAD';
 
 function loadFlex() {
+  const localPortQuery = window.location.port
+    ? '?localPort=${window.location.port}'
+    : '';
+
   if (
     typeof appConfig === 'undefined' ||
     !appConfig.sso.accountSid ||
@@ -11,17 +15,21 @@ function loadFlex() {
       'ERROR: You must have a valid appConfig with both accountSid and serviceBaseUrl set.'
     );
   } else {
-    const loginUrl = `http://www.twilio.com/service-login/flex/${appConfig.sso.accountSid || accountSid}?localPort=${window.location.port}`
+    const baseUrl = 'http://www.twilio.com/service-login/flex';
+    const loginUrl = `${baseUrl}/${appConfig.sso.accountSid || accountSid}${localPortQuery}`;
+
     if (!localStorage.getItem(FIRST_LOAD_KEY)) {
       localStorage.setItem(FIRST_LOAD_KEY, 'redirected');
       window.location.replace(loginUrl);
       return;
-    } else {
-      Twilio.Flex.create(appConfig).then(flex => {
+    }
+
+    Twilio.Flex.create(appConfig)
+      .then(flex => {
         localStorage.removeItem(REDIRECT_KEY);
-        localStorage.removeItem(FIRST_LOAD_KEY);
         flex.init('#container');
-      }).catch(err => {
+      })
+      .catch(err => {
         if (!localStorage.getItem(REDIRECT_KEY)) {
           localStorage.setItem(REDIRECT_KEY, 'redirected');
           window.location.replace(loginUrl);
@@ -29,7 +37,5 @@ function loadFlex() {
           throw new Error('Failed to authenticate user.');
         }
       });
-    }
-
   }
 }


### PR DESCRIPTION
`SCENARIO` First time loading Flex from `localhost` with SSO

`GIVEN` I am a developer launching my local version of Flex for the first time with an empty localStorage
`AND` I'm using SSO authentication with Okta
`AND` I've correctly set my URL as a `DEFAULT REDIRECT URL` from the Flex Single Sign-On settings
`WHEN` I'm redirected to the Okta authentication service for performing the login
`AND` after the login has been correctly performed
`THEN` I am redirected back to my original website

`SCENARIO` Second time loading Flex from `localhost` with SSO

`GIVEN` I am a developer launching my local version of Flex for the second time
`AND` I'm using SSO authentication with Okta
`WHEN` I open my browser to my local Flex
`THEN` the LOCAL_FLEX_PLUGIN_FIRST_LOAD key is cleared from my localStorage
`AND` I can correctly see my local version of Flex running from localhost

`SCENARIO` Third time loading Flex from `localhost` with SSO **WRONG**

`GIVEN` I am a developer launching my local version of Flex for the third time
`WHEN` I open my browser to my local Flex
`AND` because my `LOCAL_FLEX_PLUGIN_FIRST_LOAD` key is missing to my localStorage
`THEN` I am redirected to `http://www.twilio.com/service-login/flex/ACCOUNT-SID/localPort=8080`
`BUT` Because I am already logged in
`THEN` I am not taken to the Okta authentication website
`AND` Instead I remain to `https://flex.twilio.com/`