### PR TITLE
Fix call of function parse()

### DIFF
--- a/packages/create-flex-plugin/bin/create-flex-plugin
+++ b/packages/create-flex-plugin/bin/create-flex-plugin
@@ -3,6 +3,5 @@
 'use strict';
 
 require = require('esm')(module /*, options*/);
-require('../src/cli.js')
-  .default()
+require('../src/cli.js')()
   .parse(process.argv.slice(2));


### PR DESCRIPTION
Changed code to use `require('awesome_file')().function(...)` instead of `require('awesome_file').default().function(...)` - this way it [works](https://imagebin.ca/v/4VQoHeEr6B4o).

I'm using Node 8.11 and NPM 6.4.1.

Let me know if it's the best approach to solve this problem or should I change anything.


