### PR TITLE
Removed admin plugin

### DIFF
--- a/packages/create-flex-plugin/README.md
+++ b/packages/create-flex-plugin/README.md
@@ -48,7 +48,6 @@ Options:
   --accountSid, -a  The Account SID for your Flex Project
   --runtimeUrl, -r  The URL to your Twilio Flex Runtime
   --install         Auto-install dependencies         [boolean] [default: false]
-  --adminPlugin     Load admin plugin                                  [boolean]
   -h, --help        Show help                                          [boolean]
   -v, --version     Show version number                                [boolean]
 ```

--- a/packages/create-flex-plugin/__tests__/create-flex-plugin.test.js
+++ b/packages/create-flex-plugin/__tests__/create-flex-plugin.test.js
@@ -38,8 +38,7 @@ describe('create-flex-plugin', () => {
 
     // Act
     await createFlexPlugin({
-      name: 'plugin-test',
-      adminPlugin: true
+      name: 'plugin-test'
     });
 
     // Assert
@@ -53,36 +52,18 @@ describe('create-flex-plugin', () => {
     // Act
     await createFlexPlugin({
       name: 'plugin-test',
-      accountSid: 'fake-sid',
-      adminPlugin: true
+      accountSid: 'fake-sid'
     });
 
     // Assert
     expect(inquirer.prompt).not.toHaveBeenCalled();
   });
 
-  test(`should ask fro including an admin plugin if not specified`, async() => {
-    // Arrange
-    inquirer.prompt = jest.fn(() => Promise.resolve({
-      adminPlugin: false
-    }));
-
-    // Act
-    await createFlexPlugin({
-      name: 'plugin-test',
-      accountSid: 'fake-sid'
-    });
-
-    // Assert
-    expect(inquirer.prompt).toHaveBeenCalledTimes(1);
-  });
-
   test(`should not install any dependency by default`, async() => {
     // Act
     await createFlexPlugin({
       name: 'plugin-test',
-      accountSid: 'fake-sid',
-      adminPlugin: true
+      accountSid: 'fake-sid'
     });
 
     // Assert
@@ -94,7 +75,6 @@ describe('create-flex-plugin', () => {
     await createFlexPlugin({
       name: 'plugin-test',
       accountSid: 'fake-sid',
-      adminPlugin: true,
       install: true
     });
 

--- a/packages/create-flex-plugin/src/cli.js
+++ b/packages/create-flex-plugin/src/cli.js
@@ -32,16 +32,12 @@ function cli(cwd) {
           type: 'boolean',
           describe: 'Auto-install dependencies',
           default: false,
-        },
+        }
         // yarn: {
         //   type: 'boolean',
         //   describe: 'Use yarn instead of npm to install',
         //   default: false,
         // },
-        adminPlugin: {
-          type: 'boolean',
-          describe: 'Load admin plugin'
-        }
       });
     },
     argv => createFlexPlugin(argv)

--- a/packages/create-flex-plugin/src/create-flex-plugin.js
+++ b/packages/create-flex-plugin/src/create-flex-plugin.js
@@ -27,15 +27,7 @@ function getPluginJsonContent(config) {
       ],
       "src": `http://localhost:8080/${config.pluginFileName}.js`
     }
-  ]
-  if (config.adminPlugin) {
-    plugins.push({
-      "name": "Admin Plugin",
-      "version": "1.0.1",
-      "src": "https://media.twiliocdn.com/flex/flex-admin-plugin-1.0.1.js"
-    });
-  }
-
+  ];
   return plugins;
 }
 
@@ -62,18 +54,6 @@ async function promptForAccountSid() {
   return response.accountSid;
 }
 
-async function promptForAdminPlugin() {
-  const response = await inquirer.prompt([
-    {
-      type: 'confirm',
-      name: 'adminPlugin',
-      message: 'Do you want to include the Admin Plugin',
-      default: true
-    }
-  ])
-  return response.adminPlugin;
-}
-
 async function installDependencies(config) {
   const command = config.yarn ? 'yarn' : 'npm';
   const args = ['install'];
@@ -94,10 +74,6 @@ export default async function createFlexPlugin(config) {
 
   if (!config.accountSid) {
     config.accountSid = await promptForAccountSid();
-  }
-
-  if (typeof config.adminPlugin === 'undefined') {
-    config.adminPlugin = await promptForAdminPlugin();
   }
 
   config.runtimeUrl = config.runtimeUrl || 'http://localhost:8080';


### PR DESCRIPTION
Removed the admin plugin option as it seemed confusing and would get outdated.  The latest Flex admin dashboard is always available at flex.twilio.com.