### PR TITLE
pin core-js to v2

### DIFF
--- a/packages/create-flex-plugin/templates/package.json
+++ b/packages/create-flex-plugin/templates/package.json
@@ -16,8 +16,9 @@
   },
   "dependencies": {
     "@craco/craco": "^5.0.2",
-    "flex-plugin": "{{flexPluginVersion}}",
+    "core-js": "^2.6.5",
     "craco-config-flex-plugin": "{{cracoConfigVersion}}",
+    "flex-plugin": "{{flexPluginVersion}}",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "^3.0.0"


### PR DESCRIPTION
core-js@3 is not compatible with @twilio/flex-ui for testing. Thanks to @kjakobson for finding this bug. 