### PR TITLE
mention .env in migration

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -57,6 +57,8 @@ module.exports = {
 
 Then update `public/plugins.json` and update the port on `src` from `8085` to `3000`. Finally run `npm install` to install/update the new dependencies.
 
+A `.env` file was initially included to prevent the browser from opening Flex on `npm start`. This is no longer needed and can be removed.
+
 You also need to move your jest configuration into `craco.config.js`, otherwise CRA will ignore them.
 
 ## Breaking Changes


### PR DESCRIPTION
<!-- Describe your Pull Request -->

The initial version of the plugin builder didn't load Flex on `npm start`. This is now the recommended behavior.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
