### PR TITLE
fix regression w/ hyphens in plugin names

### DIFF
--- a/packages/create-flex-plugin/templates/js/src/components/CustomTaskList/CustomTaskList.Container.js
+++ b/packages/create-flex-plugin/templates/js/src/components/CustomTaskList/CustomTaskList.Container.js
@@ -5,7 +5,7 @@ import { Actions } from '../../states/CustomTaskListState';
 import CustomTaskList from './CustomTaskList';
 
 const mapStateToProps = (state) => ({
-    isOpen: state.{{pluginNamespace}}.customTaskList.isOpen,
+    isOpen: state['{{pluginNamespace}}'].customTaskList.isOpen,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/packages/create-flex-plugin/templates/ts/src/components/CustomTaskList/CustomTaskList.Container.ts
+++ b/packages/create-flex-plugin/templates/ts/src/components/CustomTaskList/CustomTaskList.Container.ts
@@ -14,7 +14,7 @@ export interface DispatchToProps {
 }
 
 const mapStateToProps = (state: AppState): StateToProps => ({
-  isOpen: state.{{pluginNamespace}}.customTaskList.isOpen,
+  isOpen: state['{{pluginNamespace}}'].customTaskList.isOpen,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<any>): DispatchToProps => ({


### PR DESCRIPTION
Generates:

> isOpen: state['signal-demo-test'].customTaskList.isOpen,

instead of

> isOpen: state.signal-demo-test.customTaskList.isOpen,