### PR TITLE
fix version cli command

### DIFF
--- a/packages/create-flex-plugin/src/lib/cli.ts
+++ b/packages/create-flex-plugin/src/lib/cli.ts
@@ -69,7 +69,7 @@ class CLI {
             description: usage,
         },
         version: {
-            alias: 'h',
+            alias: 'v',
         },
     };
 


### PR DESCRIPTION
https://github.com/twilio/flex-plugin-builder/issues/173

- Fix version cli command alias to be `-v` so that `create-flex-plugin -v` and `create-flex-plugin -h` both work as intended.