### PR TITLE
Replace rm -rf by rimraf to improve OS agnosticism

### DIFF
--- a/packages/create-flex-plugin/templates/js/package.json
+++ b/packages/create-flex-plugin/templates/js/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "bootstrap": "flex-plugin check-start",
-    "prebuild": "rm -rf build && npm run bootstrap",
+    "prebuild": "rimraf build && npm run bootstrap",
     "build": "flex-plugin build",
     "clear": "flex-plugin clear",
     "predeploy": "npm run build",
@@ -30,7 +30,8 @@
     "@twilio/flex-ui": "{{flexSdkVersion}}",
     "babel-polyfill": "^6.26.0",
     "enzyme": "^3.10.0",
-    "enzyme-adapter-react-16": "^1.14.0"
+    "enzyme-adapter-react-16": "^1.14.0",
+    "rimraf": "^3.0.0"
   },
   "browserslist": {
     "production": [

--- a/packages/create-flex-plugin/templates/ts/package.json
+++ b/packages/create-flex-plugin/templates/ts/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "bootstrap": "flex-plugin check-start",
-    "prebuild": "rm -rf build && npm run bootstrap",
+    "prebuild": "rimraf build && npm run bootstrap",
     "build": "flex-plugin build",
     "clear": "flex-plugin clear",
     "predeploy": "npm run build",
@@ -37,7 +37,8 @@
     "@types/react-redux": "^7.1.1",
     "babel-polyfill": "^6.26.0",
     "enzyme": "^3.10.0",
-    "enzyme-adapter-react-16": "^1.14.0"
+    "enzyme-adapter-react-16": "^1.14.0",
+    "rimraf": "^3.0.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Using rm -rf causes build failure on Windows (when WSL or similar has
not been enabled) rimraf selects a deletion command appropriate for the
local OS.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
