### PR TITLE
allow template url to work without template dir as well

### DIFF
--- a/packages/create-flex-plugin/README.md
+++ b/packages/create-flex-plugin/README.md
@@ -56,27 +56,23 @@ Options:
 
 ### Creating a Plugin from Custom Template
 
-When creating a new plugin, you may provide a `--template` URL to a GitHub repo that contains your custom template.
+When creating a new plugin, you may provide a `--template` URL to a GitHub repo that contains your custom template. Create Flex Plugin will copy over the entire content from the directory, including all scripts, files and directories that are not part of the src folder. The repo has to be a valid node repository which means that it expects files such as `package.json`, `.gitignore`, `README.md`, etc to be present.
 
 #### Template Directory Hierarchy
 
 Your GitHub project should be
-
 ```
 /
-  template/
-    src/
+     src/
       index.js
       ...
     ...
 ```
 
-Create Flex Plugin will copy over the content from the `template` directory, and expects a `index.js`. 
-
-We will provide a `public/` folder as well as `package.json` but you may override these by including them in your `template/` folder.
+Create Flex Plugin will copy over the content from the directory, and expects an `index.js` in the src folder. We will also provide a `public/` folder as well as `package.json` but you may override these by including them in your base GitHub repo.
 
 See [flex-plugin-template-sample](https://github.com/ktalebian/flex-plugin-template-sample) for a basic example and 
-[flex-plugin-template-now](https://github.com/cwkendall/flex-plugin-template-now) for a more complete example.
+[plugin-agent-autoresponse](github.com/johnfischelli/plugin-agent-autoresponse) for a more complete example.
 
 #### Version Support
 

--- a/packages/create-flex-plugin/README.md
+++ b/packages/create-flex-plugin/README.md
@@ -56,7 +56,7 @@ Options:
 
 ### Creating a Plugin from Custom Template
 
-When creating a new plugin, you may provide a `--template` URL to a GitHub repo that contains your custom template. Create Flex Plugin will copy over the entire content from the directory, including all scripts, files and directories that are not part of the src folder. The repo has to be a valid node repository which means that it expects files such as `package.json`, `.gitignore`, `README.md`, etc to be present.
+When creating a new plugin, you may provide a `--template` URL to a GitHub repo containing the source code of a Flex plugin. Create Flex Plugin will copy over the entire content from the directory, including all scripts, files and directories that are not part of the src folder. The repo has to be a valid node repository which means that it expects files such as `package.json`, `.gitignore`, `README.md`, etc to be present.
 
 #### Template Directory Hierarchy
 
@@ -69,7 +69,7 @@ Your GitHub project should be
     ...
 ```
 
-Create Flex Plugin will copy over the content from the directory, and expects an `index.js` in the src folder. We will also provide a `public/` folder as well as `package.json` but you may override these by including them in your base GitHub repo.
+Create Flex Plugin will copy over the content from the directory, and expects an `index.js` in the src folder. We will also provide a `public/` folder and a `package.json` but you may override these by including them in your base GitHub repo.
 
 See [flex-plugin-template-sample](https://github.com/ktalebian/flex-plugin-template-sample) for a basic example and 
 [plugin-agent-autoresponse](github.com/johnfischelli/plugin-agent-autoresponse) for a more complete example.

--- a/packages/create-flex-plugin/src/utils/__tests__/github.test.ts
+++ b/packages/create-flex-plugin/src/utils/__tests__/github.test.ts
@@ -6,7 +6,8 @@ import * as github from '../github';
 describe('github', () => {
   let mockAxios: MockAdapter;
   const gitHubUrl = 'https://github.com/twilio/flex-plugin-builder';
-  const apiGithubUrl = 'https://api.github.com/repos/twilio/flex-plugin-builder/contents/template?ref=master';
+  const apiGithubUrlTemplated = 'https://api.github.com/repos/twilio/flex-plugin-builder/contents/template?ref=master';
+  const apiGithubUrl = 'https://api.github.com/repos/twilio/flex-plugin-builder/contents?ref=master';
   const githubInfo = {
     ref: 'master',
     owner: 'twilio',
@@ -14,7 +15,14 @@ describe('github', () => {
   };
 
   beforeEach(() => {
+    jest.resetAllMocks();
+    jest.resetModules();
+
     mockAxios = new MockAdapter(axios);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
   });
 
   describe('parseGitHubUrl', () => {
@@ -40,17 +48,97 @@ describe('github', () => {
   });
 
   describe('downloadRepo', () => {
-    it('should call _downloadDir', async () => {
+    it('should call _downloadDir with a templated url', async () => {
       const _downloadDir = jest
         .spyOn(github, '_downloadDir')
         .mockResolvedValue(null);
+      const _hasTemplateDir = jest
+        .spyOn(github, '_hasTemplateDir')
+        .mockResolvedValue(true);
 
       await github.downloadRepo(githubInfo, '/dir');
 
+      expect(_hasTemplateDir).toHaveBeenCalledTimes(1);
+      expect(_hasTemplateDir).toHaveBeenCalledWith(githubInfo);
+
       expect(_downloadDir).toHaveBeenCalledTimes(1);
-      expect(_downloadDir).toHaveBeenCalledWith(apiGithubUrl, '/dir');
+      expect(_downloadDir).toHaveBeenCalledWith(apiGithubUrlTemplated, '/dir', github._getBaseRegex(githubInfo, true));
 
       _downloadDir.mockRestore();
+      _hasTemplateDir.mockRestore();
+    });
+
+    it('should call _downloadDir with a normal url', async () => {
+      const _downloadDir = jest
+        .spyOn(github, '_downloadDir')
+        .mockResolvedValue(null);
+      const _hasTemplateDir = jest
+        .spyOn(github, '_hasTemplateDir')
+        .mockResolvedValue(false);
+
+      await github.downloadRepo(githubInfo, '/dir');
+
+      expect(_hasTemplateDir).toHaveBeenCalledTimes(1);
+      expect(_hasTemplateDir).toHaveBeenCalledWith(githubInfo);
+
+      expect(_downloadDir).toHaveBeenCalledTimes(1);
+      expect(_downloadDir).toHaveBeenCalledWith(apiGithubUrl, '/dir', github._getBaseRegex(githubInfo, false));
+
+      _downloadDir.mockRestore();
+      _hasTemplateDir.mockRestore();
+    });
+  });
+
+  describe('_getBaseRegex', () => {
+    it('should return a templated base regex', () => {
+      const regex = github._getBaseRegex(githubInfo, true);
+      expect(regex).toEqual('\/twilio\/flex-plugin-builder\/master\/template\/');
+    });
+
+    it('should return a non-templated base regex', () => {
+      const regex = github._getBaseRegex(githubInfo, false);
+      expect(regex).toEqual('\/twilio\/flex-plugin-builder\/master\/');
+    });
+  });
+
+  describe('_hasTemplateDir', () => {
+    it('should return true if there is a template dir', async () => {
+      const resp = [{
+        name: 'foo'
+      }, {
+        name: 'template',
+        type: 'dir'
+      }];
+
+      mockAxios.onGet().reply(() => Promise.resolve([200, resp]));
+
+      expect(await github._hasTemplateDir(githubInfo)).toEqual(true);
+    });
+
+    it('should return false if there is a template file', async () => {
+      const resp = [{
+        name: 'foo'
+      }, {
+        name: 'template',
+        type: 'file'
+      }];
+
+      mockAxios.onGet().reply(() => Promise.resolve([200, resp]));
+
+      expect(await github._hasTemplateDir(githubInfo)).toEqual(false);
+    });
+
+    it('should return false if there is no template dir', async () => {
+      const resp = [{
+        name: 'foo'
+      }, {
+        name: 'something-else',
+        type: 'dir'
+      }];
+
+      mockAxios.onGet().reply(() => Promise.resolve([200, resp]));
+
+      expect(await github._hasTemplateDir(githubInfo)).toEqual(false);
     });
   });
 
@@ -69,7 +157,7 @@ describe('github', () => {
 
     it('should do nothing if api returns empty result', async () => {
       mockAxios.onGet().reply(() => Promise.resolve([200, []]));
-      await github._downloadDir(apiGithubUrl, '/dir');
+      await github._downloadDir(apiGithubUrlTemplated, '/dir', '');
 
       expect(_downloadFile).not.toHaveBeenCalled();
     });
@@ -84,7 +172,7 @@ describe('github', () => {
       }];
 
       mockAxios.onGet().reply(() => Promise.resolve([200, resp]));
-      await github._downloadDir(apiGithubUrl, '/dir');
+      await github._downloadDir(apiGithubUrlTemplated, '/dir', 'github.com\/twilio\/template\/');
 
       expect(_downloadFile).toHaveBeenCalledTimes(2);
       expect(_downloadFile).toHaveBeenNthCalledWith(1, resp[0].download_url, '/dir/file1.js');
@@ -102,13 +190,13 @@ describe('github', () => {
       }];
 
       mockAxios.onGet().reply((request) => {
-        if (request.url === apiGithubUrl) {
+        if (request.url === apiGithubUrlTemplated) {
           return Promise.resolve([200, firstResp]);
         } else {
           return Promise.resolve([200, secondResp]);
         }
       });
-      await github._downloadDir(apiGithubUrl, '/dir');
+      await github._downloadDir(apiGithubUrlTemplated, '/dir', 'github.com\/twilio\/template\/');
 
       expect(_downloadFile).toHaveBeenCalledTimes(1);
       expect(_downloadFile).toHaveBeenNthCalledWith(1, secondResp[0].download_url, '/dir/file2.js');
@@ -123,7 +211,7 @@ describe('github', () => {
       mockAxios.onGet().reply(() => Promise.resolve([200, resp]));
 
       try {
-        await github._downloadDir(apiGithubUrl, '/dir');
+        await github._downloadDir(apiGithubUrlTemplated, '/dir', 'github.com\/twilio\/template\/');
       } catch (e) {
         expect(e.message).toContain('Unexpected content type');
         done();
@@ -139,7 +227,7 @@ describe('github', () => {
       mockAxios.onGet().reply(() => Promise.resolve([200, resp]));
 
       try {
-        await github._downloadDir(apiGithubUrl, '/dir');
+        await github._downloadDir(apiGithubUrlTemplated, '/dir', 'github.com\/twilio\/template\/');
       } catch (e) {
         expect(e.message).toContain('invalid URL');
         done();

--- a/packages/create-flex-plugin/src/utils/github.ts
+++ b/packages/create-flex-plugin/src/utils/github.ts
@@ -2,7 +2,6 @@ import axios, { AxiosRequestConfig } from 'flex-dev-utils/dist/axios';
 import { mkdirpSync } from 'flex-dev-utils/dist/fs';
 import fs from 'fs';
 import path from 'path';
-import has = Reflect.has;
 
 export interface GitHubInfo {
   owner: string;

--- a/packages/create-flex-plugin/src/utils/github.ts
+++ b/packages/create-flex-plugin/src/utils/github.ts
@@ -2,6 +2,7 @@ import axios, { AxiosRequestConfig } from 'flex-dev-utils/dist/axios';
 import { mkdirpSync } from 'flex-dev-utils/dist/fs';
 import fs from 'fs';
 import path from 'path';
+import has = Reflect.has;
 
 export interface GitHubInfo {
   owner: string;
@@ -59,9 +60,41 @@ export const parseGitHubUrl = (url: string): GitHubInfo => {
  * @return null
  */
 export const downloadRepo = async (info: GitHubInfo, dir: string) => {
-  const url = `https://api.github.com/repos/${info.owner}/${info.repo}/contents/template?ref=${info.ref}`;
+  const hasTemplateDir = await _hasTemplateDir(info);
 
-  return _downloadDir(url, dir);
+  const url = hasTemplateDir
+    ? `https://api.github.com/repos/${info.owner}/${info.repo}/contents/template?ref=${info.ref}`
+    : `https://api.github.com/repos/${info.owner}/${info.repo}/contents?ref=${info.ref}`;
+
+  return _downloadDir(url, dir, _getBaseRegex(info, hasTemplateDir));
+};
+
+/**
+ * Generates a regex for matching the download url
+ * @param info {GitHubInfo} the GitHub information
+ * @param hasTemplateDir {boolean} whether the GitHub repo has a template directory
+ * @private
+ */
+export const _getBaseRegex = (info: GitHubInfo, hasTemplateDir: boolean) => {
+  const baseRegex = `\/${info.owner}\/${info.repo}\/${info.ref}\/`;
+  if (hasTemplateDir) {
+    return baseRegex + 'template\/';
+  }
+
+  return baseRegex;
+};
+
+/**
+ * Checks for back-ward compatible changes; returns true is the repo has a template/ directory
+ * @param info {GitHubInfo}  the {@link GitHubInfo} information
+ * @private
+ */
+export const _hasTemplateDir = async (info: GitHubInfo) => {
+  const url = `https://api.github.com/repos/${info.owner}/${info.repo}/contents?ref=${info.ref}`;
+
+  return axios.get<GitHubContent[]>(url)
+    .then((resp) => resp.data)
+    .then(contents => contents.some(content => content.name === 'template' && content.type === 'dir'));
 };
 
 /**
@@ -69,22 +102,24 @@ export const downloadRepo = async (info: GitHubInfo, dir: string) => {
  *
  * @param url {string}  the url to download
  * @param dir {string}  the path to the directory to save the content
+ * @param baseRegex {String} the base path regex
  * @private
  */
-export const _downloadDir = async (url: string, dir: string): Promise<null> => {
+export const _downloadDir = async (url: string, dir: string, baseRegex: string): Promise<null> => {
   return axios.get<GitHubContent[]>(url)
     .then((resp) => resp.data)
     .then((contents) => {
       const promises = contents.map((content) => {
         if (content.type === GitHubContentType.Dir) {
-          return _downloadDir(content.url, dir);
+          return _downloadDir(content.url, dir, baseRegex);
         }
 
         if (content.type !== GitHubContentType.File) {
           throw new Error(`Unexpected content type ${content.type}`);
         }
 
-        const relativePath = content.download_url.match(/\/template\/(.+)\??/);
+        const regex = new RegExp(baseRegex + '(.+)\\??');
+        const relativePath = content.download_url.match(regex);
         if (!relativePath || relativePath.length !== 2) {
           throw new Error('Received invalid URL template');
         }


### PR DESCRIPTION
* Support `--template` repo to contain source code at the root level instead of `/template` directory as well