### PR TITLE
Remove obsolete setting from appConfig

### DIFF
--- a/packages/create-flex-plugin/templates/core/public/appConfig.example.js
+++ b/packages/create-flex-plugin/templates/core/public/appConfig.example.js
@@ -14,7 +14,6 @@ var appConfig = {
   sso: {
     accountSid: accountSid
   },
-  ytica: false,
   logLevel: 'info',
   showSupervisorDesktopView: true,
 };


### PR DESCRIPTION
The `ytica` key in the `appConfig` has been obsolete since about version `1.0`.  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
