### PR TITLE
Make spawn() work in Git Bash on Windows

### DIFF
--- a/packages/flex-dev-utils/src/spawn.ts
+++ b/packages/flex-dev-utils/src/spawn.ts
@@ -14,7 +14,7 @@ type ShellCmd = 'node' | 'yarn' | 'npm';
  * @param options   the spawn argument
  */
 export const spawn = async (shellCmd: ShellCmd, args: string[], options: object = DefaultOptions) => {
-  const spawnOptions = { ... { shell: process.env.SHELL }, ...options};
+  const spawnOptions = {...options};
 
   try {
     const {


### PR DESCRIPTION
This PR fixes the following issue:

When I run `twilio flex:plugins:start`after creating a Flex plugin with twilio-cli, the command fails with the following error:

```
internal/modules/cjs/loader.js:983
  throw err;
  ^

Error: Cannot find module 'C:\Usersszx.twilio-clinode_modulesflex-plugin-scriptsdistscriptsstart.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:980:15)
    at Function.Module._load (internal/modules/cjs/loader.js:862:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
    at internal/main/run_main_module.js:18:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

For me it only happens when using Git Bash on Windows. It looks like the backslashes vanished from the path and it became invalid. The correct path is:

```
C:\Users\szx\.twilio-cli\node_modules\flex-plugin-scripts\dist\scripts\start.js
```

This PR fixes the error. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
