### PR TITLE
Make updatePackageVersion() also update version field in package-lock.json

### DIFF
--- a/packages/flex-dev-utils/src/fs.ts
+++ b/packages/flex-dev-utils/src/fs.ts
@@ -95,6 +95,11 @@ export const checkFilesExist = (...files: string[]) => {
 export const getPackageJsonPath = (forModule: boolean = false) => path.join(getCwd(), 'package.json');
 
 /**
+ * Gets package-lock.json path
+ */
+export const getPackageLockJsonPath = () => path.join(process.cwd(), 'package-lock.json');
+
+/**
  * Updates the package.json version field
  *
  * @param version the new version
@@ -104,6 +109,13 @@ export const updateAppVersion = (version: string) => {
   packageJson.version = version;
 
   fs.writeFileSync(getPackageJsonPath(), JSON.stringify(packageJson, null, 2));
+
+  if (fs.existsSync(getPackageLockJsonPath())) {
+    const packageLockJson = readPackageJson(getPackageLockJsonPath());
+    packageLockJson.version = version;
+
+    fs.writeFileSync(getPackageLockJsonPath(), JSON.stringify(packageLockJson, null, 2));
+  }
 };
 
 /**


### PR DESCRIPTION
I noticed that when I run `twilio flex:plugins:deploy` it updates the version in `package.json` but does not update it in `package-lock.json`, and the 2 versions get out of sync. 

On the next run of `npm install`, the version in `package-lock.json` gets fixed up automatically, but at that point the change is already committed and the plugin is deployed. 

It would be nice if the command updated the version in both places. So this is why I'm creating this PR.

Another thing implemented here is the following:

Instead of using 2 spaces for indentation, detect the current indent size of package.json using `detect-indent` and use that style when writing the new JSON.

I'm not sure why npm updated so many package versions, I just ran `npm install --save-dev detect indent`... 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
