### PR TITLE
Update local CORS origin

### DIFF
--- a/packages/flex-plugin-scripts/src/scripts/start/pluginServer.ts
+++ b/packages/flex-plugin-scripts/src/scripts/start/pluginServer.ts
@@ -31,7 +31,7 @@ export const _getLocalPlugins = () => JSON.parse(readFileSync(pluginsJsonPath)) 
  * @private
  */
 export const _getHeaders = (port: number) => ({
-  'Access-Control-Allow-Origin': `http://localhost:${port}`,
+  'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET',
   'Access-Control-Allow-Headers': 'Content-Type, X-Flex-Version, X-Flex-JWE',
   'Access-Control-Allow-Credentials': 'true',


### PR DESCRIPTION
if a user is using custom domain for local development cors is blocking the /plugins changing cors origin to *

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
