### PR TITLE
create-flex-plugin cli.ts: deduped parameter descs

### DIFF
--- a/packages/create-flex-plugin/src/lib/cli.ts
+++ b/packages/create-flex-plugin/src/lib/cli.ts
@@ -39,7 +39,7 @@ export default class CLI {
     template: {
       alias: 't',
       type: 'string',
-      describe: 'A URL to a template directory',
+      describe: 'A GitHub URL that contains your template',
       default: '',
     },
     accountSid: {
@@ -52,7 +52,7 @@ export default class CLI {
       alias: 'r',
       type: 'boolean',
       default: false,
-      describe: 'Auto-install dependencies',
+      describe: 'The URL to your Twilio Flex Runtime',
     },
     install: {
       alias: 'i',


### PR DESCRIPTION
The describe values for two parameters were duplicated incorrectly. I also updated some descriptions to match the readme when they were lacking in clarity.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
