### PR TITLE
FLEXY-2924 handle asset version collision and prompt user for overwrite

### DIFF
--- a/packages/flex-plugin-scripts/src/scripts/__tests__/deploy.test.ts
+++ b/packages/flex-plugin-scripts/src/scripts/__tests__/deploy.test.ts
@@ -375,6 +375,30 @@ describe('DeployScript', () => {
       _getAccount.mockRestore();
     });
 
+    it('should overwrite the existing asset if the caller is the CLI, duplicate route is found, user does want to overwite, and not in CI', async () => {
+      process.env.CI = 'false';
+      const options = {
+        isPluginsCli: true,
+        isPublic: true,
+        overwrite: true,
+        isPluginsPilot: false,
+        disallowVersioning: false,
+      };
+      const checkFilesExist = jest.spyOn(fs, 'checkFilesExist').mockReturnValue(true);
+      const _getAccount = jest.spyOn(deployScript, '_getAccount').mockReturnThis();
+      const _verifyPath = jest.spyOn(deployScript, '_verifyPath').mockReturnValue(false);
+      const deploySuccessful = jest.spyOn(prints, 'deploySuccessful');
+
+      await deployScript._doDeploy('1.0.0', options);
+
+      expect(_getAccount).toHaveBeenCalledTimes(1);
+      expect(deploySuccessful).toHaveBeenCalledTimes(1);
+
+      checkFilesExist.mockRestore();
+      _verifyPath.mockRestore();
+      _getAccount.mockRestore();
+    });
+
     it('should deploy and write a success message', async () => {
       const options = {
         isPluginsCli: false,

--- a/packages/flex-plugin-scripts/src/scripts/__tests__/deploy.test.ts
+++ b/packages/flex-plugin-scripts/src/scripts/__tests__/deploy.test.ts
@@ -290,7 +290,9 @@ describe('DeployScript', () => {
       checkFilesExist.mockRestore();
     });
 
-    it('should quit if duplicate route is found', async (done) => {
+    it('should quit if duplicate route is found if in CI', async (done) => {
+      const OLD_ENV = process.env;
+      process.env.CI = 'true';
       const options = {
         isPublic: true,
         overwrite: false,
@@ -310,6 +312,7 @@ describe('DeployScript', () => {
 
       checkFilesExist.mockRestore();
       verifyPath.mockRestore();
+      process.env = OLD_ENV;
     });
 
     it('should deploy and write a success message', async () => {

--- a/packages/flex-plugin-scripts/src/scripts/deploy.ts
+++ b/packages/flex-plugin-scripts/src/scripts/deploy.ts
@@ -242,6 +242,11 @@ export const _doDeploy = async (nextVersion: string, options: Options): Promise<
     return data;
   });
 
+  // Register service sid with Config service
+  await progress('Registering plugin with Flex', async () => {
+    await configurationClient.registerSid(runtime.service.sid);
+  });
+
   const deployResult = {
     serviceSid: runtime.service.sid,
     accountSid: runtime.service.account_sid,
@@ -255,11 +260,6 @@ export const _doDeploy = async (nextVersion: string, options: Options): Promise<
   if (routeCollision && !options.overwrite) {
     return deployResult;
   }
-
-  // Register service sid with Config service
-  await progress('Registering plugin with Flex', async () => {
-    await configurationClient.registerSid(runtime.service.sid);
-  });
 
   // Create a build, and poll regularly until build is complete
   await progress('Deploying a new build of your Twilio Runtime', async () => {

--- a/packages/flex-plugin-scripts/src/scripts/deploy.ts
+++ b/packages/flex-plugin-scripts/src/scripts/deploy.ts
@@ -25,6 +25,7 @@ import getRuntime from '../utils/runtime';
 const allowedBumps = ['major', 'minor', 'patch', 'version'];
 
 export interface Options {
+  isPluginsCli: boolean;
   isPublic: boolean;
   overwrite: boolean;
   disallowVersioning: boolean;
@@ -196,7 +197,7 @@ export const _doDeploy = async (nextVersion: string, options: Options): Promise<
           logger.newline();
           logger.warning('Plugin already exists and the flag --overwrite is going to overwrite this plugin.');
         }
-      } else if (env.isCI()) {
+      } else if (env.isCI() || !options.isPluginsCli) {
         throw new FlexPluginError(`You already have a plugin with the same version: ${pluginUrl}`);
       }
     }
@@ -283,6 +284,7 @@ const deploy = async (...argv: string[]): Promise<DeployResult> => {
   let nextVersion = argv[1] as string;
   const bump = argv[0];
   const opts: Options = {
+    isPluginsCli: argv.includes('--plugins-cli'),
     isPublic: argv.includes('--public'),
     overwrite: argv.includes('--overwrite') || disallowVersioning,
     isPluginsPilot: argv.includes('--pilot-plugins-api'),

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/deploy.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/deploy.test.ts
@@ -1,12 +1,20 @@
 /* eslint-disable camelcase */
 import { CLIParseError } from '@oclif/parser/lib/errors';
 import { TwilioCliError } from 'flex-dev-utils';
+import * as credentials from 'flex-dev-utils/dist/credentials';
+import * as runtime from 'flex-plugin-scripts/dist/utils/runtime';
+import * as fs from 'flex-dev-utils/dist/fs';
 import { PluginVersionResource } from 'flex-plugins-api-client/dist/clients/pluginVersions';
 import { PluginResource } from 'flex-plugins-api-client';
 
 import createTest, { getPrintMethod, mockGetPkg, mockGetter, mockPrintMethod } from '../../../framework';
 import FlexPluginsDeploy, { parseVersionInput } from '../../../../commands/flex/plugins/deploy';
 import ServerlessClient from '../../../../clients/ServerlessClient';
+
+jest.mock('flex-dev-utils/dist/credentials');
+jest.mock('flex-plugin-scripts/dist/utils/runtime');
+jest.mock('flex-dev-utils/dist/fs');
+jest.mock('flex-dev-utils/dist/updateNotifier');
 
 describe('Commands/FlexPluginsDeploy', () => {
   const serviceSid = 'ZS00000000000000000000000000000';
@@ -46,13 +54,21 @@ describe('Commands/FlexPluginsDeploy', () => {
     date_created: '2020',
     date_updated: '2020',
   };
+  const paths = {
+    app: {
+      version: '1.0.0',
+    },
+    assetBaseUrlTemplate: 'template',
+  };
 
   const getServerlessSid = jest.fn();
   const hasLegacy = jest.fn();
+  const OLD_ENV = process.env;
 
   beforeEach(() => {
     jest.resetAllMocks();
     jest.restoreAllMocks();
+    process.env = { ...OLD_ENV };
   });
 
   const getCommand = async (...args: string[]) => {
@@ -405,5 +421,47 @@ describe('Commands/FlexPluginsDeploy', () => {
     const cmd = await getCommand();
 
     expect(cmd.checkCompatibility).toEqual(true);
+  });
+
+  it('should check for collision if not in CI', async () => {
+    process.env.CI = 'false';
+    const cmd = await getCommand();
+    const getCredential = jest
+      .spyOn(credentials, 'getCredential')
+      .mockResolvedValue({ username: 'user', password: 'pass' });
+
+    // @ts-ignore
+    jest.spyOn(runtime, 'default').mockResolvedValue({ environment: { sid: 'sid' } });
+    // @ts-ignore
+    jest.spyOn(fs, 'readPackageJson').mockReturnValue({
+      version: '1.0.0',
+      name: 'plugin-test',
+    });
+    // @ts-ignore
+    jest.spyOn(fs, 'getPaths').mockReturnValue(paths);
+
+    await cmd.hasCollisionAndOverwrite();
+
+    expect(getCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not check for collision if in CI', async () => {
+    process.env.CI = 'true';
+    const cmd = await getCommand();
+    const getCredential = jest.spyOn(credentials, 'getCredential');
+
+    // @ts-ignore
+    jest.spyOn(runtime, 'default').mockResolvedValue({ environment: { sid: 'sid' } });
+    // @ts-ignore
+    jest.spyOn(fs, 'readPackageJson').mockReturnValue({
+      version: '1.0.0',
+      name: 'plugin-test',
+    });
+    // @ts-ignore
+    jest.spyOn(fs, 'getPaths').mockReturnValue(paths);
+
+    await cmd.hasCollisionAndOverwrite();
+
+    expect(getCredential).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/plugin-flex/src/commands/flex/plugins/deploy.ts
+++ b/packages/plugin-flex/src/commands/flex/plugins/deploy.ts
@@ -137,6 +137,10 @@ export default class FlexPluginsDeploy extends FlexPlugin {
     this.prints.deploySuccessful(this.pkg.name, pluginVersion.private ? 'private' : 'public', deployedData);
   }
 
+  /**
+   * Checks if there is already an uploaded asset with the same version and prompts user with an option to override if so
+   * @returns {Promise<boolean>}
+   */
   async hasCollisionAndOverwrite(): Promise<boolean> {
     const credentials = await getCredential();
     const runtime = await getRuntime(credentials);

--- a/packages/plugin-flex/src/commands/flex/plugins/deploy.ts
+++ b/packages/plugin-flex/src/commands/flex/plugins/deploy.ts
@@ -117,9 +117,11 @@ export default class FlexPluginsDeploy extends FlexPlugin {
       false,
     );
 
-    const hasCollisionAndOverwrite = await this.hasCollisionAndOverwrite();
-    if (hasCollisionAndOverwrite) {
-      args.push('--overwrite');
+    if (!env.isCI) {
+      const hasCollisionAndOverwrite = await this.hasCollisionAndOverwrite();
+      if (hasCollisionAndOverwrite) {
+        args.push('--overwrite');
+      }
     }
 
     const deployedData: DeployResult = await progress(

--- a/packages/plugin-flex/src/commands/flex/plugins/deploy.ts
+++ b/packages/plugin-flex/src/commands/flex/plugins/deploy.ts
@@ -117,11 +117,9 @@ export default class FlexPluginsDeploy extends FlexPlugin {
       false,
     );
 
-    if (!env.isCI) {
-      const hasCollisionAndOverwrite = await this.hasCollisionAndOverwrite();
-      if (hasCollisionAndOverwrite) {
-        args.push('--overwrite');
-      }
+    const hasCollisionAndOverwrite = await this.hasCollisionAndOverwrite();
+    if (hasCollisionAndOverwrite) {
+      args.push('--overwrite');
     }
 
     const deployedData: DeployResult = await progress(

--- a/packages/plugin-flex/src/commands/flex/plugins/deploy.ts
+++ b/packages/plugin-flex/src/commands/flex/plugins/deploy.ts
@@ -1,8 +1,11 @@
 import { PluginVersionResource } from 'flex-plugins-api-client/dist/clients/pluginVersions';
 import semver from 'semver';
-import { DeployResult } from 'flex-plugin-scripts/dist/scripts/deploy';
+import { DeployResult, _verifyPath } from 'flex-plugin-scripts/dist/scripts/deploy';
+import getRuntime from 'flex-plugin-scripts/dist/utils/runtime';
 import { CLIParseError } from '@oclif/parser/lib/errors';
-import { TwilioCliError, progress } from 'flex-dev-utils';
+import { FlexPluginError, TwilioCliError, progress, getCredential, env } from 'flex-dev-utils';
+import { getPaths } from 'flex-dev-utils/dist/fs';
+import { confirm } from 'flex-dev-utils/dist/inquirer';
 import { PluginResource } from 'flex-plugins-api-client';
 
 import * as flags from '../../../utils/flags';
@@ -113,6 +116,12 @@ export default class FlexPluginsDeploy extends FlexPlugin {
       },
       false,
     );
+
+    const hasCollisionAndOverwrite = await this.hasCollisionAndOverwrite();
+    if (hasCollisionAndOverwrite) {
+      args.push('--overwrite');
+    }
+
     const deployedData: DeployResult = await progress(
       `Uploading ${name}`,
       async () => this.runScript('deploy', [...this.scriptArgs, ...args]),
@@ -126,6 +135,33 @@ export default class FlexPluginsDeploy extends FlexPlugin {
     );
 
     this.prints.deploySuccessful(this.pkg.name, pluginVersion.private ? 'private' : 'public', deployedData);
+  }
+
+  async hasCollisionAndOverwrite(): Promise<boolean> {
+    const credentials = await getCredential();
+    const runtime = await getRuntime(credentials);
+    if (!runtime.environment) {
+      throw new FlexPluginError('No Runtime environment was found');
+    }
+
+    const pluginBaseUrl = getPaths().assetBaseUrlTemplate.replace('%PLUGIN_VERSION%', this.nextVersion as string);
+    const collision = runtime.build ? !_verifyPath(pluginBaseUrl, runtime.build) : false;
+
+    if (collision && !env.isCI()) {
+      const answer = await confirm(
+        'Plugin package has already been uploaded previously for this version of the plugin. Would you like to overwrite it?',
+        'N',
+      );
+
+      if (answer) {
+        return true;
+      }
+
+      const pluginUrl = `https://${runtime.environment.domain_name}${pluginBaseUrl}/bundle.js`;
+      throw new FlexPluginError(`You already have a plugin with the same version: ${pluginUrl}`);
+    }
+
+    return false;
   }
 
   /**

--- a/packages/plugin-flex/src/sub-commands/flex-plugin.ts
+++ b/packages/plugin-flex/src/sub-commands/flex-plugin.ts
@@ -447,6 +447,7 @@ export default class FlexPlugin extends baseCommands.TwilioClientCommand {
     const extra = [];
     if (scriptName !== 'test') {
       extra.push('--core-cwd', this.pluginRootDir);
+      extra.push('--plugins-cli', this.pluginRootDir);
     }
 
     // eslint-disable-next-line global-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -462,7 +463,7 @@ export default class FlexPlugin extends baseCommands.TwilioClientCommand {
   // @ts-ignore
   async spawnScript(scriptName: string, argv = this.scriptArgs): SpawnPromise {
     const scriptPath = require.resolve(`flex-plugin-scripts/dist/scripts/${scriptName}`);
-    return spawn('node', [scriptPath, ...argv, '--run-script', '--core-cwd', this.pluginRootDir]);
+    return spawn('node', [scriptPath, ...argv, '--run-script', '--core-cwd', '--plugins-cli', this.pluginRootDir]);
   }
 
   /**


### PR DESCRIPTION
- when an asset version already exists and user does not overwrite, don't upload the new build to serverless and continue registering with plugins api using the existing version
- when an asset version already exists and user does overwrite, overwrite the existing asset in serverless and register the new asset using plugins api
- if on CI, throw an error if an asset version already exists (this is the current behavior)

<img width="1792" alt="Screen Shot 2021-02-18 at 11 55 29 PM" src="https://user-images.githubusercontent.com/4912483/108459557-e1688c80-7244-11eb-8508-6e5231fbc359.png">
<img width="1792" alt="Screen Shot 2021-02-18 at 11 54 58 PM" src="https://user-images.githubusercontent.com/4912483/108459558-e2012300-7244-11eb-889f-78ba0419871e.png">
