### PR TITLE
Load order create configuration

### DIFF
--- a/packages/flex-plugin-e2e-tests/src/utils/api.ts
+++ b/packages/flex-plugin-e2e-tests/src/utils/api.ts
@@ -38,7 +38,11 @@ const getPluginVersion = async (name: string, version: string): Promise<PluginVe
 };
 
 const getLatestPluginVersion = async (name: string): Promise<PluginVersionResource | null> => {
-  return versionsClient.latest(name);
+  try {
+    return versionsClient.latest(name);
+  } catch (e) {
+    return null;
+  }
 };
 
 const getPlugin = async (name: string): Promise<PluginResource> => {

--- a/packages/flex-plugins-api-toolkit/package.json
+++ b/packages/flex-plugins-api-toolkit/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "npm run lint -- --fix",
     "prepublish": "npm run build",
     "test": "cd ../.. && jest packages/flex-plugins-api-toolkit --color",
-    "test:watch": "cd ../.. && jest packages/flnpm ex-plugins-api-toolkit --watch --color"
+    "test:watch": "cd ../.. && jest packages/flex-plugins-api-toolkit --watch --color"
   },
   "dependencies": {
     "flex-plugin-utils-http": "4.7.5-beta.0",

--- a/packages/flex-plugins-api-toolkit/package.json
+++ b/packages/flex-plugins-api-toolkit/package.json
@@ -37,12 +37,13 @@
     "lint:fix": "npm run lint -- --fix",
     "prepublish": "npm run build",
     "test": "cd ../.. && jest packages/flex-plugins-api-toolkit --color",
-    "test:watch": "cd ../.. && jest packages/flex-plugins-api-toolkit --watch --color"
+    "test:watch": "cd ../.. && jest packages/flnpm ex-plugins-api-toolkit --watch --color"
   },
   "dependencies": {
     "flex-plugin-utils-http": "4.7.5-beta.0",
     "flex-plugins-api-client": "4.7.5-beta.0",
     "flex-plugins-utils-env": "4.7.5-beta.0",
+    "flex-plugins-utils-logger": "4.7.5-beta.0",
     "flex-plugins-utils-exception": "4.7.5-beta.0",
     "lodash.clonedeep": "^4.5.0"
   },

--- a/packages/flex-plugins-api-toolkit/src/scripts/createConfiguration.ts
+++ b/packages/flex-plugins-api-toolkit/src/scripts/createConfiguration.ts
@@ -106,7 +106,6 @@ export default function createConfiguration(
         .filter(Boolean),
     );
     const list: string[] = [];
-    // = option.addPlugins;
     if (option.fromConfiguration === 'active') {
       const release = await releasesClient.active();
       if (release) {


### PR DESCRIPTION
Enforce load-order for enabling plugins:
* Adding new plugins are appended to the end of the list
* Updating an existing plugin's version updates the plugin _in place_ (preserves the order)