### PR TITLE
Check source map size in build command

### DIFF
--- a/packages/flex-plugin-scripts/src/prints/fileTooLarge.ts
+++ b/packages/flex-plugin-scripts/src/prints/fileTooLarge.ts
@@ -1,14 +1,14 @@
 import { env, logger } from 'flex-dev-utils';
 import { printList } from 'flex-dev-utils/dist/prints';
 
-export default (size: number, max: number): void => {
+export default (type: 'bundle' | 'sourcemap', size: number, max: number): void => {
   env.setQuiet(false);
 
   // Round to 1 decimal
   size = Math.round(size * 10) / 10;
 
   logger.newline();
-  logger.info(`--Plugin bundle size **${size}MB** exceeds allowed limit of **${max}MB**.--`);
+  logger.info(`--Plugin ${type} size **${size}MB** exceeds allowed limit of **${max}MB**.--`);
   logger.newline();
   logger.info('Consider the following optimizations:');
 

--- a/packages/flex-plugin-scripts/src/scripts/build.ts
+++ b/packages/flex-plugin-scripts/src/scripts/build.ts
@@ -88,8 +88,15 @@ const build = async (...argv: string[]): Promise<void> => {
     const { warnings, bundles } = await _runWebpack();
     const bundleSize = getFileSizeInMB(getPaths().app.bundlePath);
     const sourceMapSize = getFileSizeInMB(getPaths().app.sourceMapPath);
-    if (bundleSize >= MAX_BUILD_SIZE_MB || sourceMapSize >= MAX_BUILD_SIZE_MB) {
-      fileTooLarge(bundleSize, MAX_BUILD_SIZE_MB);
+
+    if (bundleSize >= MAX_BUILD_SIZE_MB) {
+      fileTooLarge('bundle', bundleSize, MAX_BUILD_SIZE_MB);
+      exit(1, argv);
+      return;
+    }
+
+    if (sourceMapSize >= MAX_BUILD_SIZE_MB) {
+      fileTooLarge('sourcemap', bundleSize, MAX_BUILD_SIZE_MB);
       exit(1, argv);
       return;
     }

--- a/packages/flex-plugin-scripts/src/scripts/build.ts
+++ b/packages/flex-plugin-scripts/src/scripts/build.ts
@@ -86,9 +86,10 @@ const build = async (...argv: string[]): Promise<void> => {
 
   try {
     const { warnings, bundles } = await _runWebpack();
-    const fileSize = getFileSizeInMB(getPaths().app.bundlePath);
-    if (fileSize >= MAX_BUILD_SIZE_MB) {
-      fileTooLarge(fileSize, MAX_BUILD_SIZE_MB);
+    const bundleSize = getFileSizeInMB(getPaths().app.bundlePath);
+    const sourceMapSize = getFileSizeInMB(getPaths().app.sourceMapPath);
+    if (bundleSize >= MAX_BUILD_SIZE_MB || sourceMapSize >= MAX_BUILD_SIZE_MB) {
+      fileTooLarge(bundleSize, MAX_BUILD_SIZE_MB);
       exit(1, argv);
       return;
     }


### PR DESCRIPTION
### Updated

- CLI Build command to check size of the source map
- CLI Build UTs

###  Added

- File identifier to `fileTooLarge` 
- UT for checking source map's size