### PR TITLE
Remove account sid check in E2E when running flex:plugins:start

### DIFF
--- a/packages/flex-plugin-e2e-tests/src/tests/step006.ts
+++ b/packages/flex-plugin-e2e-tests/src/tests/step006.ts
@@ -20,11 +20,6 @@ const testSuite: TestSuite = async ({ scenario, config, secrets }: TestParams): 
     // Plugin loads
     await Browser.loginViaConsole(cookies, config.consoleBaseUrl, scenario.plugin.localhostUrl, 'agent-desktop');
     await assertion.browser.userIsOnView('Agent Desktop');
-
-    // Verify that user is on the right account
-    const accountSid = await Browser.getFlexAccountSid();
-    assertion.equal(accountSid, secrets.api.accountSid);
-
     await assertion.browser.pluginIsVisible(scenario.plugin.componentText);
 
     // Verify hot reload

--- a/packages/flex-plugin-e2e-tests/src/utils/browser.ts
+++ b/packages/flex-plugin-e2e-tests/src/utils/browser.ts
@@ -53,6 +53,7 @@ export class Browser {
    * Gets account sid from browser's console
    */
   static async getFlexAccountSid(): Promise<string> {
+    await this.browser.sleep(10000);
     return this.browser.executeScript<string>(
       'return Twilio.Flex.Manager.getInstance().serviceConfiguration.account_sid',
     );

--- a/packages/flex-plugin-e2e-tests/src/utils/browser.ts
+++ b/packages/flex-plugin-e2e-tests/src/utils/browser.ts
@@ -53,7 +53,6 @@ export class Browser {
    * Gets account sid from browser's console
    */
   static async getFlexAccountSid(): Promise<string> {
-    await this.browser.sleep(10000);
     return this.browser.executeScript<string>(
       'return Twilio.Flex.Manager.getInstance().serviceConfiguration.account_sid',
     );


### PR DESCRIPTION
### Updated

- Removed account sid assert from step006 in E2E tests