### PR TITLE
Increased page navigation timeout from 30s to 60s

### DIFF
--- a/packages/flex-plugin-e2e-tests/src/utils/pages/view/base.ts
+++ b/packages/flex-plugin-e2e-tests/src/utils/pages/view/base.ts
@@ -18,7 +18,7 @@ export abstract class Base {
    */
   protected async goto({ baseUrl, path }: { baseUrl: string; path?: string }): Promise<void> {
     const fullPath = path ? `${baseUrl}/${path}` : baseUrl;
-    await this.page.goto(fullPath);
+    await this.page.goto(fullPath, { waitUntil: 'load', timeout: 60000 });
   }
 
   /**


### PR DESCRIPTION
### Updated

- Increased default navigation timeout from 30 to 60 seconds