### PR TITLE
FLEXY-3865 sanitize plugins CLI inputs

### DIFF
--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/deploy.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/deploy.test.ts
@@ -201,7 +201,7 @@ describe('Commands/FlexPluginsDeploy', () => {
       Version: deployResult.nextVersion,
       PluginUrl: deployResult.pluginUrl,
       Private: !deployResult.isPublic,
-      Changelog: defaultChangelog,
+      Changelog: 'sample%20changlog',
     });
   });
 
@@ -247,7 +247,7 @@ describe('Commands/FlexPluginsDeploy', () => {
     expect(cmd.pluginsClient.upsert).toHaveBeenCalledWith({
       UniqueName: pkg.name,
       FriendlyName: pkg.name,
-      Description: 'some description',
+      Description: 'some%20description',
     });
   });
 

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/start.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/start.test.ts
@@ -227,6 +227,7 @@ describe('Commands/FlexPluginsStart', () => {
 
   it('should read and set flex-ui-source', async () => {
     const flexUISrc = 'http://localhost:8080/twilio-flex-ui.dev.browser.js';
+    const encodedFlexUISrc = 'http%3A%2F%2Flocalhost%3A8080%2Ftwilio-flex-ui.dev.browser.js';
     const cmd = await createTest(FlexPluginsStart)('--flex-ui-source', flexUISrc);
 
     jest.spyOn(cmd, 'builderVersion', 'get').mockReturnValue(4);
@@ -257,8 +258,8 @@ describe('Commands/FlexPluginsStart', () => {
     expect(cmd.runScript).toHaveBeenCalledWith(preStartCheck, ['--name', pkg.name]);
     expect(cmd.runScript).toHaveBeenCalledWith(preScriptCheck, ['--name', pkg.name]);
     expect(cmd.spawnScript).toHaveBeenCalledWith('start', ['plugin', '--name', pkg.name, '--port', '100']);
-    expect(cmd._flags[flexUiSource]).toEqual(flexUISrc);
-    expect(env.getFlexUISrc()).toEqual(flexUISrc);
+    expect(cmd._flags[flexUiSource]).toEqual(encodedFlexUISrc);
+    expect(env.getFlexUISrc()).toEqual(encodedFlexUISrc);
   });
 
   it('should error due to invalid flex-ui-source', async () => {

--- a/packages/plugin-flex/src/__tests__/utils/parser.test.ts
+++ b/packages/plugin-flex/src/__tests__/utils/parser.test.ts
@@ -2,26 +2,28 @@ import { CLIParseError } from '@oclif/parser/lib/errors';
 
 import * as parser from '../../utils/parser';
 
-const stringToBeTrimmed = 'needs trimming';
-
 describe('Utils/Parser', () => {
-  it('should trim only strings', () => {
-    const obj = {
-      str1: `${stringToBeTrimmed} `,
-      str2: `  ${stringToBeTrimmed}  `,
-      str3: 'is good',
-      num: 123,
-      bool: true,
-      obj: {},
-    };
-    const trimmed = parser._trim(obj);
+  describe('_sanitize', () => {
+    it('should sanitize only strings', () => {
+      const obj = {
+        str1: `needs trimming `,
+        str2: `  needs trimming  `,
+        str3: 'is good',
+        str4: '   aaa&Plugins={"plugin_version":"FV000","phase":3}',
+        num: 123,
+        bool: true,
+        obj: {},
+      };
+      const sanitized = parser._sanitize(obj);
 
-    expect(trimmed.str1).toEqual(stringToBeTrimmed);
-    expect(trimmed.str2).toEqual(stringToBeTrimmed);
-    expect(trimmed.str3).toEqual('is good');
-    expect(trimmed.num).toEqual(123);
-    expect(trimmed.bool).toEqual(true);
-    expect(trimmed.obj).toEqual({});
+      expect(sanitized.str1).toEqual('needs%20trimming');
+      expect(sanitized.str2).toEqual('needs%20trimming');
+      expect(sanitized.str3).toEqual('is%20good');
+      expect(sanitized.str4).toEqual('aaa%26Plugins%3D%7B%22plugin_version%22%3A%22FV000%22%2C%22phase%22%3A3%7D');
+      expect(sanitized.num).toEqual(123);
+      expect(sanitized.bool).toEqual(true);
+      expect(sanitized.obj).toEqual({});
+    });
   });
 
   describe('_validate', () => {

--- a/packages/plugin-flex/src/utils/parser.ts
+++ b/packages/plugin-flex/src/utils/parser.ts
@@ -7,14 +7,14 @@ type Input<F> = Parser.Input<F>;
 type Output<F, A> = Parser.Output<F, A>;
 
 /**
- * Trims the object
+ * Sanitize the object
  * @param obj
  * @private
  */
-export const _trim = <F>(obj: F): F => {
+export const _sanitize = <F>(obj: F): F => {
   Object.keys(obj).forEach((key) => {
     if (typeof obj[key] === 'string') {
-      obj[key] = obj[key].trim();
+      obj[key] = encodeURIComponent(obj[key].trim());
     }
   });
 
@@ -126,8 +126,8 @@ const parser =
   (options?: Input<F>, argv: string[] = []): Output<F, A> => {
     const parsed: Output<F, A> = _combineFlags(OclifParser(_prepareFlags(options), argv), options);
 
-    parsed.flags = _trim(parsed.flags);
-    parsed.args = _trim(parsed.args);
+    parsed.flags = _sanitize(parsed.flags);
+    parsed.args = _sanitize(parsed.args);
 
     if (options && options.flags && parsed.flags) {
       _validate(parsed.flags, options.flags, parsed);


### PR DESCRIPTION
- Sanitize plugins CLI inputs.


After:
```
❯ twilio flex:plugins:release --plugin 'plugin-eight@0.0.1' --name 'aaa&Plugins={"plugin_version":"FVc03bd70d3e9e4d9793262c95ab295aac","phase":3}' --description 'bbb'
 ›   Warning: twilio-cli update available from 2.35.0 to 3.0.0.
 ›   Error: Flag --name=aaa%26Plugins%3D%7B%22plugin_version%22%3A%22FVc03bd70d3e9e4d9793262c95ab295aac%22%2C
 ›   %22phase%22%3A3%7D cannot be longer than 100 characters
 ›   See more help with --help
```

Before:
```
❯ twilio flex:plugins:release --plugin 'plugin-eight@0.0.1' --name 'aaa&Plugins={"plugin_version":"FVc03bd70d3e9e4d9793262c95ab295aac","phase":3}' --description 'bbb'
 ›   Warning: twilio-cli update available from 2.35.0 to 3.0.0.
Using profile acai - archive testing (09.28.21) (AC096f0a77dc69ecceeb534f18b78b9d47)

✖ Plugin version sids FVc03bd70d3e9e4d9793262c95ab295aac are duplicate.
Plugin version sids FVc03bd70d3e9e4d9793262c95ab295aac are duplicate.
```