### PR TITLE
Add proxy support for configuration client

### DIFF
--- a/packages/flex-plugin-scripts/src/clients/configurations.ts
+++ b/packages/flex-plugin-scripts/src/clients/configurations.ts
@@ -28,6 +28,7 @@ export default class ConfigurationClient {
     this.http = new HttpClient({
       baseURL: `https://flex-api.twilio.com/${ConfigurationClient.version}`,
       auth: { username, password },
+      supportProxy: true,
     });
   }
 


### PR DESCRIPTION
The `ConfigurationClient` was missing the attribute that adds support for proxying requests. This results in the `deploy`
failing from clients that are isolated from the network and can reach out only through a proxy.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
