### PR TITLE
chore: allow latest Node LTS

### DIFF
--- a/packages/flex-plugin-scripts/package.json
+++ b/packages/flex-plugin-scripts/package.json
@@ -59,7 +59,7 @@
     "react-emotion": "9.2.12"
   },
   "engines": {
-    "node": "^12 || ^14 || ^16"
+    "node": "^12 || ^14 || ^16 || ^18"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Currently this logic prevents this package from being installed on Node 18, which is now the current LTS. This change will allow end users to install this on Node 18 and run the scripts. Alternatively, this package should consider using `>=` instead of `||` so that it can just specify a minimum node version instead of being so prescriptive.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
