### PR TITLE
Bumping serverless node version to 16

### DIFF
--- a/packages/flex-plugin-scripts/src/clients/builds.ts
+++ b/packages/flex-plugin-scripts/src/clients/builds.ts
@@ -37,7 +37,7 @@ export interface BuildData {
 }
 
 export default class BuildClient {
-  private static NodeEngine = 'node14';
+  private static NodeEngine = 'node16';
 
   private static timeoutMsec: number = 60_000;
 

--- a/packages/plugin-flex/src/prints/upgradePlugin.ts
+++ b/packages/plugin-flex/src/prints/upgradePlugin.ts
@@ -1,6 +1,7 @@
 import { Logger, singleLineString, boxen, confirm, coloredStrings } from '@twilio/flex-dev-utils';
 import { printList } from '@twilio/flex-dev-utils/dist/prints';
 
+import FlexPlugin from '../sub-commands/flex-plugin';
 import { exit } from '../utils/general';
 
 const cracoUpgradeGuideLink = 'https://twilio.com';
@@ -52,7 +53,9 @@ const upgradeToFlexUI2 = (logger: Logger) => () => {
  */
 const scriptSucceeded = (logger: Logger) => (needsInstall: boolean) => {
   logger.newline();
-  logger.success('🎉 Your plugin was successfully migrated to use the latest (v5) version of Flex Plugins CLI.');
+  logger.success(
+    `🎉 Your plugin was successfully migrated to use the latest (v${FlexPlugin.BUILDER_VERSION}) version of Flex Plugins CLI.`,
+  );
   logger.newline();
 
   logger.info('**Next Steps:**');


### PR DESCRIPTION
- Bumping serverless node version to 16
- Updated the plugin upgrade success logger message to use the BUILDER_VERSION instead of the hardcoded version value

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
