### PR TITLE
FLEXY-4359

### DIFF
--- a/changelog/v6.md
+++ b/changelog/v6.md
@@ -1,7 +1,7 @@
 ## 6.0.4 (Jan 10th, 2023)
 
 ### Fixed
-- Change the markdown for italic in logger in flex-dev-utils
+- Modified the markdown formatter syntax for italic from *italic* to _italic_
 
 ## 6.0.3 (Nov 2nd, 2022)
 

--- a/changelog/v6.md
+++ b/changelog/v6.md
@@ -1,7 +1,7 @@
 ## 6.0.4 (Jan 10th, 2023)
 
 ### Fixed
-- Modified the markdown formatter syntax for italic from *italic* to _italic_
+- Modified the markdown formatter syntax for italic which is used by the logger.
 
 ## 6.0.3 (Nov 2nd, 2022)
 

--- a/changelog/v6.md
+++ b/changelog/v6.md
@@ -1,3 +1,8 @@
+## 6.0.4 (Jan 10th, 2023)
+
+### Fixed
+- Change the markdown for italic in logger in flex-dev-utils
+
 ## 6.0.3 (Nov 2nd, 2022)
 
 ### Fixed

--- a/packages/flex-dev-utils/src/logger/lib/__tests__/logger.test.ts
+++ b/packages/flex-dev-utils/src/logger/lib/__tests__/logger.test.ts
@@ -248,14 +248,14 @@ describe('logger', () => {
       });
 
       it('should do just italic', () => {
-        expect(logger.markdown('text with ?italic word? markdown')).toEqual('text with italic word markdown');
+        expect(logger.markdown('text with _italic word_ markdown')).toEqual('text with italic word markdown');
 
         expect(italic).toHaveBeenCalledTimes(1);
         expect(italic).toHaveBeenCalledWith('italic word');
       });
 
       it('should do italic and bold', () => {
-        expect(logger.markdown('text **with** ?everything? and ?anything? **that** can be')).toEqual(
+        expect(logger.markdown('text **with** _everything_ and _anything_ **that** can be')).toEqual(
           'text with everything and anything that can be',
         );
 

--- a/packages/flex-dev-utils/src/logger/lib/__tests__/logger.test.ts
+++ b/packages/flex-dev-utils/src/logger/lib/__tests__/logger.test.ts
@@ -248,14 +248,14 @@ describe('logger', () => {
       });
 
       it('should do just italic', () => {
-        expect(logger.markdown('text with *italic word* markdown')).toEqual('text with italic word markdown');
+        expect(logger.markdown('text with ?italic word? markdown')).toEqual('text with italic word markdown');
 
         expect(italic).toHaveBeenCalledTimes(1);
         expect(italic).toHaveBeenCalledWith('italic word');
       });
 
       it('should do italic and bold', () => {
-        expect(logger.markdown('text **with** *everything* and *anything* **that** can be')).toEqual(
+        expect(logger.markdown('text **with** ?everything? and ?anything? **that** can be')).toEqual(
           'text with everything and anything that can be',
         );
 

--- a/packages/flex-dev-utils/src/logger/lib/logger.ts
+++ b/packages/flex-dev-utils/src/logger/lib/logger.ts
@@ -74,8 +74,8 @@ export class Logger {
       render: coloredStrings.bold,
     },
     italic: {
-      openChars: '\\*',
-      closeChars: '\\*',
+      openChars: '\\?',
+      closeChars: '\\?',
       render: coloredStrings.italic,
     },
     code: {

--- a/packages/flex-dev-utils/src/logger/lib/logger.ts
+++ b/packages/flex-dev-utils/src/logger/lib/logger.ts
@@ -249,7 +249,7 @@ export class Logger {
   };
 
   /**
-   * Provides basic markdown support. Currently supported bold **bold** and italic *italic*
+   * Provides basic markdown support. Currently supported bold **bold** and italic _italic_
    * @param msg
    */
   public markdown = (msg?: string): string | undefined => {

--- a/packages/flex-dev-utils/src/logger/lib/logger.ts
+++ b/packages/flex-dev-utils/src/logger/lib/logger.ts
@@ -74,8 +74,8 @@ export class Logger {
       render: coloredStrings.bold,
     },
     italic: {
-      openChars: '\\?',
-      closeChars: '\\?',
+      openChars: '\\_',
+      closeChars: '\\_',
       render: coloredStrings.italic,
     },
     code: {


### PR DESCRIPTION
<!-- Describe your Pull Request -->
When upgrading a plugin from v4- to latest version, as required by current Plugin CLI in order to deploy a plugin that was created in older Plugin CLI versions, we get the following message:

![image](https://user-images.githubusercontent.com/112855846/211050413-c395bb35-48c6-4610-abbf-d4f9071f1823.png)

import  _as FlexPlugin from '@twilio/flex-plugin';_

* is being intepreted to change it to italic in console thus i am changing the italic conversion in console from '*' to '?'

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
