### PR TITLE
FLEXY-4620 Update e2e triggers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ parameters:
   run_e2e_test:
     default: false
     type: boolean
+  run_e2e_test_nightly:
+    default: false
+    type: boolean
   run_pr_validator:
     default: true
     type: boolean
@@ -53,8 +56,7 @@ workflows:
     jobs:
      - split-config/generate-config:
           find-config-regex: \./\.circleci/configs/.*\.yml
-          continuation-parameters: |
-           {
-              "run_e2e_test_nightly": true,
-              "run_pr_validator": false
-           }
+          parameters: 
+            run_e2e_test_nightly: true
+            run_pr_validator: false
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,3 +44,19 @@ workflows:
     jobs:
       - split-config/generate-config:
           find-config-regex: \./\.circleci/configs/.*\.yml
+  generate-config-nightly:
+    triggers:
+      - schedule:
+          cron: "0 16 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+     - split-config/generate-config:
+          find-config-regex: \./\.circleci/configs/.*\.yml
+          continuation-parameters: |
+           {
+              "run_e2e_test_nightly": true,
+              "run_pr_validator": false
+           }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,5 @@
 version: 2.1
 
-setup: true
-
 parameters:
   run_e2e_test:
     default: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 version: 2.1
 
+setup: true
+
 parameters:
   run_e2e_test:
     default: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,18 +45,4 @@ workflows:
     jobs:
       - split-config/generate-config:
           find-config-regex: \./\.circleci/configs/.*\.yml
-  generate-config-nightly:
-    triggers:
-      - schedule:
-          cron: "0 16 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-     - split-config/generate-config:
-          find-config-regex: \./\.circleci/configs/.*\.yml
-          parameters: 
-            run_e2e_test_nightly: true
-            run_pr_validator: false
 

--- a/.circleci/configs/e2e_test.yml
+++ b/.circleci/configs/e2e_test.yml
@@ -4,6 +4,9 @@ parameters:
   run_e2e_test:
     default: false
     type: boolean
+  run_e2e_test_nightly:
+    default: false
+    type: boolean
   package_version:
     default: ""
     type: string
@@ -321,13 +324,7 @@ workflows:
               node-version: ["16.20.0"]
 
   workflow_nightly-e2e:
-    triggers:
-      - schedule:
-          cron: "0 16 * * *"
-          filters:
-            branches:
-              only:
-                - main
+    when: << pipeline.parameters.run_e2e_test >>
     jobs:
       - job_e2e-test-linux-node16:
           matrix:

--- a/.circleci/configs/e2e_test.yml
+++ b/.circleci/configs/e2e_test.yml
@@ -324,7 +324,7 @@ workflows:
               node-version: ["16.20.0"]
 
   workflow_nightly-e2e:
-    when: << pipeline.parameters.run_e2e_test >>
+    when: << pipeline.parameters.run_e2e_test_nightly >>
     jobs:
       - job_e2e-test-linux-node16:
           matrix:


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Since we started using dynamic configuration, the nightly e2e workflow isn't triggered because it's not in the config.yml. To fix this, we need to make sure the pipeline(generate config) runs daily at 4 pm UTC.

This PR makes the necessary changes trigger the e2e workflow from a  scheduled trigger set in the circle [project settings](https://app.circleci.com/settings/project/github/twilio/flex-plugin-builder/triggers?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Ftwilio%2Fflex-plugin-builder&triggerSource=&scheduledTriggerId=1c4b6306-92f7-4a2a-8d9b-cb928ef43ca5&success=true). We are introducing a new pipeline parameter which will be passed from the settings and it will run the e2e nightly workflow. we are also sending run_pr_validator parameter with the value false(default value is true) so that it won't get triggered. Attaching a screenshot of the new trigger set . [Here](https://circleci.com/docs/migrate-scheduled-workflows-to-scheduled-pipelines/#) is the link to the circleci  scheduled pipelines doc and also an example of [nightly scheduled](https://circleci.com/docs/set-a-nightly-scheduled-pipeline/) pipeline
<img width="335" alt="Screenshot 2023-07-07 at 11 59 00 AM" src="https://github.com/twilio/flex-plugin-builder/assets/109077609/02abd36e-223e-4c57-8583-bc6fe18c64a4">

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
