### PR TITLE
Fix for loading remote plugins in localhost

### DIFF
--- a/.github/workflows/pr_e2e.yaml
+++ b/.github/workflows/pr_e2e.yaml
@@ -49,7 +49,7 @@ jobs:
     with:
       BRANCH: ${{ needs.get-version.outputs.branch }}
       NPM_IGNORE_PREFIX: ${{ vars.NPM_IGNORE_PREFIX }}
-      PACKAGE_VERSION: ${{ github.event.label.name == vars.E2E_LABEL && 'latest' || needs.get-version.outputs.version }}
+      PACKAGE_VERSION: 6.3.3-alpha.202404031130
       FLEX_UI_VERSION: latest
     secrets:
       CONSOLE_EMAIL: ${{ secrets.CONSOLE_EMAIL }}

--- a/.github/workflows/pr_e2e.yaml
+++ b/.github/workflows/pr_e2e.yaml
@@ -49,7 +49,7 @@ jobs:
     with:
       BRANCH: ${{ needs.get-version.outputs.branch }}
       NPM_IGNORE_PREFIX: ${{ vars.NPM_IGNORE_PREFIX }}
-      PACKAGE_VERSION: 6.3.3-alpha.202404031130
+      PACKAGE_VERSION: ${{ github.event.label.name == vars.E2E_LABEL && 'latest' || needs.get-version.outputs.version }}
       FLEX_UI_VERSION: latest
     secrets:
       CONSOLE_EMAIL: ${{ secrets.CONSOLE_EMAIL }}

--- a/changelog/v6.md
+++ b/changelog/v6.md
@@ -1,3 +1,9 @@
+## 6.3.3 (Apr 4th, 2024)
+
+### Fixed
+
+- Fixed the issue with loading remote plugins in localhost which broke after Flex started using partitioned cookies to store Flex JWE token.
+
 ## 6.3.1 (Feb 8th, 2024)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -12219,6 +12219,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-Fvuyi354Z+uayxzIGCwYTayFKocfV7TuDYZClCdIP9ckhvAu/ixDtCB6qx2TT0FKjPLf1f3P/J1rgf6lPs64mw==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/dotenv-webpack": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/dotenv-webpack/-/dotenv-webpack-6.0.0.tgz",
@@ -17773,6 +17782,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -43043,6 +43072,7 @@
       "license": "MIT",
       "dependencies": {
         "@k88/pipe-compose": "^2.5.0",
+        "@segment/analytics-node": "^1.3.0",
         "@twilio/flex-plugins-utils-env": "6.3.2",
         "@twilio/flex-plugins-utils-exception": "6.3.2",
         "address": "^1.1.2",
@@ -43729,6 +43759,7 @@
         "babel-loader": "^8.3.0",
         "babel-plugin-named-asset-import": "^0.3.7",
         "babel-preset-react-app": "^10.0.0",
+        "cookie-parser": "1.4.6",
         "css-loader": "^5.1.3",
         "dotenv": "^10.0.0",
         "dotenv-webpack": "^6.0.4",
@@ -43752,6 +43783,7 @@
         "webpack-dev-server": "^3.11.3"
       },
       "devDependencies": {
+        "@types/cookie-parser": "1.4.7",
         "@types/dotenv-webpack": "^6.0.0",
         "@types/node-ipc": "9.1.3",
         "@types/tapable": "^1.0.8",

--- a/packages/flex-plugin-e2e-tests/src/tests/step010.ts
+++ b/packages/flex-plugin-e2e-tests/src/tests/step010.ts
@@ -44,7 +44,7 @@ const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: 
   // Start all 3 plugins (Note: cwd is plugin3 in this scenario since plugin is the remote one)
   const twilioCliResult = await spawn(
     'twilio',
-    ['flex:plugins:start', '--name', `${plugin1.name}@${plugin1.version}`, '--name', plugin2.name],
+    ['flex:plugins:start', '--name', `${plugin1.name}@${plugin1.version}`, '--name', plugin2.name, '-l', 'debug'],
     { detached: true, cwd: plugin3.dir },
   );
   await Promise.all([startPlugin(plugin2.localhostUrl), startPlugin(plugin3.localhostUrl)]);

--- a/packages/flex-plugin-e2e-tests/src/tests/step010.ts
+++ b/packages/flex-plugin-e2e-tests/src/tests/step010.ts
@@ -52,7 +52,7 @@ const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: 
   try {
     // Load local plugin
     await Browser.create({ flex: plugin3.localhostUrl, twilioConsole: config.consoleBaseUrl });
-    await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort, false);
+    await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort);
 
     // Check if local plugin loaded okay
     await assertion.app.view.agentDesktop.isVisible();

--- a/packages/flex-plugin-e2e-tests/src/tests/step010.ts
+++ b/packages/flex-plugin-e2e-tests/src/tests/step010.ts
@@ -4,22 +4,6 @@ import { replaceInFile } from 'replace-in-file';
 import { TestSuite, TestParams, testParams, PluginType } from '../core';
 import { spawn, Browser, pluginHelper, joinPath, assertion, killChildProcess } from '../utils';
 
-/**
- * Log into Flex to set the required flex.twilio.com cookies
- * @param config Contains the urls requires to load in the browser
- * @param secrets Contains account info
- */
-export const setupFlexBeforeLocalhost = async (
-  config: TestParams['config'],
-  secrets: TestParams['secrets'],
-): Promise<void> => {
-  await Browser.create({ flex: config.hostedFlexBaseUrl, twilioConsole: config.consoleBaseUrl });
-  await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort);
-
-  // Check if Flex loaded okay
-  await assertion.app.view.adminDashboard.isVisible();
-};
-
 // Starting multiple plugins using 2 local and one remote works
 const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: TestParams): Promise<void> => {
   const plugin1 = scenario.plugins[0];
@@ -66,11 +50,8 @@ const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: 
   await Promise.all([startPlugin(plugin2.localhostUrl), startPlugin(plugin3.localhostUrl)]);
 
   try {
-    // Login to Flex and setup the required flex.twilio.com cookies
-    await setupFlexBeforeLocalhost(config, secrets);
-
     // Load local plugin
-    await Browser.loadNewPage({ flex: plugin3.localhostUrl, twilioConsole: config.consoleBaseUrl });
+    await Browser.create({ flex: plugin3.localhostUrl, twilioConsole: config.consoleBaseUrl });
     await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort, false);
 
     // Check if local plugin loaded okay

--- a/packages/flex-plugin-e2e-tests/src/tests/step011.ts
+++ b/packages/flex-plugin-e2e-tests/src/tests/step011.ts
@@ -3,7 +3,6 @@ import semver from 'semver';
 
 import { TestSuite, TestParams, testParams } from '../core';
 import { spawn, Browser, pluginHelper, api, assertion, killChildProcess } from '../utils';
-import { setupFlexBeforeLocalhost } from './step010';
 
 // Starting multiple plugins using --include-remote works
 const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: TestParams): Promise<void> => {
@@ -53,11 +52,8 @@ const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: 
   );
 
   try {
-    // Login to Flex and setup the required flex.twilio.com cookies
-    await setupFlexBeforeLocalhost(config, secrets);
-
     // Load local plugin
-    await Browser.loadNewPage({ flex: plugin3.localhostUrl, twilioConsole: config.consoleBaseUrl });
+    await Browser.create({ flex: plugin3.localhostUrl, twilioConsole: config.consoleBaseUrl });
     await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort, false);
 
     // Check if local plugin loaded okay

--- a/packages/flex-plugin-e2e-tests/src/tests/step011.ts
+++ b/packages/flex-plugin-e2e-tests/src/tests/step011.ts
@@ -54,7 +54,7 @@ const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: 
   try {
     // Load local plugin
     await Browser.create({ flex: plugin3.localhostUrl, twilioConsole: config.consoleBaseUrl });
-    await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort, false);
+    await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort);
 
     // Check if local plugin loaded okay
     await assertion.app.view.agentDesktop.isVisible();

--- a/packages/flex-plugin-e2e-tests/src/tests/step012.ts
+++ b/packages/flex-plugin-e2e-tests/src/tests/step012.ts
@@ -4,8 +4,8 @@ import semver from 'semver';
 
 import { TestSuite, TestParams, testParams } from '../core';
 import { spawn, Browser, pluginHelper, joinPath, assertion, killChildProcess, api } from '../utils';
-import { setupFlexBeforeLocalhost } from './step010';
 
+// Start the 2 local plugins and 1 versioned plugin
 const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: TestParams): Promise<void> => {
   const ext = scenario.isTS ? 'tsx' : 'jsx';
   const tmpComponentText = 'This is the new text for the next version!';
@@ -57,11 +57,8 @@ const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: 
   await Promise.all([startPlugin(plugin2.localhostUrl), startPlugin(plugin3.localhostUrl)]);
 
   try {
-    // Login to Flex and setup the required flex.twilio.com cookies
-    await setupFlexBeforeLocalhost(config, secrets);
-
     // Load local plugin
-    await Browser.loadNewPage({ flex: plugin3.localhostUrl, twilioConsole: config.consoleBaseUrl });
+    await Browser.create({ flex: plugin3.localhostUrl, twilioConsole: config.consoleBaseUrl });
     await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort, false);
 
     // Check if local plugin loaded okay

--- a/packages/flex-plugin-e2e-tests/src/tests/step012.ts
+++ b/packages/flex-plugin-e2e-tests/src/tests/step012.ts
@@ -59,7 +59,7 @@ const testSuite: TestSuite = async ({ scenario, config, secrets, environment }: 
   try {
     // Load local plugin
     await Browser.create({ flex: plugin3.localhostUrl, twilioConsole: config.consoleBaseUrl });
-    await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort, false);
+    await Browser.app.twilioConsole.login('admin', secrets.api.accountSid, config.localhostPort);
 
     // Check if local plugin loaded okay
     await assertion.app.view.agentDesktop.isVisible();

--- a/packages/flex-plugin-e2e-tests/src/utils/browser.ts
+++ b/packages/flex-plugin-e2e-tests/src/utils/browser.ts
@@ -26,15 +26,6 @@ export class Browser {
     assertion.app.init(this.app);
   }
 
-  static async loadNewPage(baseUrls: BaseUrl): Promise<void> {
-    this._page = await this._browser.newPage();
-    await this._page.setRequestInterception(true);
-    this._attachLogListener();
-    this._attachNetworkInterceptor();
-    this.app = new App(this._page, baseUrls);
-    assertion.app.init(this.app);
-  }
-
   static async kill(): Promise<void> {
     try {
       this._page.removeAllListeners();

--- a/packages/flex-plugin-e2e-tests/src/utils/browser.ts
+++ b/packages/flex-plugin-e2e-tests/src/utils/browser.ts
@@ -49,17 +49,6 @@ export class Browser {
       }
       return request.continue();
     });
-
-    this._page.on('requestfailed', async (event) => {
-      try {
-        logger.error(`*** REQUEST FAILED FOR: ${event.url()} ***`);
-        logger.error(`*** Failure message: ${JSON.stringify(event.failure())} ***`);
-        const response = await event.response()?.json();
-        logger.error('*** Response ***', response);
-      } catch (e) {
-        // ignore
-      }
-    });
   }
 
   /**

--- a/packages/flex-plugin-e2e-tests/src/utils/browser.ts
+++ b/packages/flex-plugin-e2e-tests/src/utils/browser.ts
@@ -51,10 +51,14 @@ export class Browser {
     });
 
     this._page.on('requestfailed', async (event) => {
-      logger.error(`*** REQUEST FAILED FOR: ${event.url()} ***`);
-      logger.error(`*** Failure message: ${event.failure()} ***`);
-      const response = await event.response()?.json();
-      logger.error('*** Response ***', response);
+      try {
+        logger.error(`*** REQUEST FAILED FOR: ${event.url()} ***`);
+        logger.error(`*** Failure message: ${JSON.stringify(event.failure())} ***`);
+        const response = await event.response()?.json();
+        logger.error('*** Response ***', response);
+      } catch (e) {
+        // ignore
+      }
     });
   }
 

--- a/packages/flex-plugin-e2e-tests/src/utils/browser.ts
+++ b/packages/flex-plugin-e2e-tests/src/utils/browser.ts
@@ -49,6 +49,13 @@ export class Browser {
       }
       return request.continue();
     });
+
+    this._page.on('requestfailed', async (event) => {
+      logger.error(`*** REQUEST FAILED FOR: ${event.url()} ***`);
+      logger.error(`*** Failure message: ${event.failure()} ***`);
+      const response = await event.response()?.json();
+      logger.error('*** Response ***', response);
+    });
   }
 
   /**

--- a/packages/flex-plugin-webpack/package.json
+++ b/packages/flex-plugin-webpack/package.json
@@ -46,6 +46,7 @@
     "babel-loader": "^8.3.0",
     "babel-plugin-named-asset-import": "^0.3.7",
     "babel-preset-react-app": "^10.0.0",
+    "cookie-parser": "1.4.6",
     "css-loader": "^5.1.3",
     "dotenv": "^10.0.0",
     "dotenv-webpack": "^6.0.4",
@@ -69,6 +70,7 @@
     "webpack-dev-server": "^3.11.3"
   },
   "devDependencies": {
+    "@types/cookie-parser": "1.4.7",
     "@types/dotenv-webpack": "^6.0.0",
     "@types/node-ipc": "9.1.3",
     "@types/tapable": "^1.0.8",

--- a/packages/flex-plugin-webpack/src/compiler.ts
+++ b/packages/flex-plugin-webpack/src/compiler.ts
@@ -115,20 +115,22 @@ export default (
         compiler.hooks.tsCompiled.call(messages.warnings, messages.errors);
       }
 
-      const config = readRunPluginsJson();
+      setTimeout(() => {
+        const config = readRunPluginsJson();
 
-      // Add the plugin to the loaded plugins configuration file
-      if (isJavaScriptServer) {
-        config.loadedPlugins.push(getPaths().app.name);
-        writeJSONFile(config, getCliPaths().localPluginsJsonPath);
-      }
+        // Add the plugin to the loaded plugins configuration file
+        if (isJavaScriptServer) {
+          config.loadedPlugins.push(getPaths().app.name);
+          writeJSONFile(config, getCliPaths().localPluginsJsonPath);
+        }
 
-      // Check to see if the plugin is the last bundle to be loaded
-      onCompile({
-        result,
-        appName: getPaths().app.name,
-        lastPluginBundle: config.plugins.length === config.loadedPlugins.length,
-      });
+        // Check to see if the plugin is the last bundle to be loaded
+        onCompile({
+          result,
+          appName: getPaths().app.name,
+          lastPluginBundle: config.plugins.length === config.loadedPlugins.length,
+        });
+      }, Math.round(Math.random() * 500));
     });
 
     return compiler;

--- a/packages/flex-plugin-webpack/src/compiler.ts
+++ b/packages/flex-plugin-webpack/src/compiler.ts
@@ -130,7 +130,7 @@ export default (
           appName: getPaths().app.name,
           lastPluginBundle: config.plugins.length === config.loadedPlugins.length,
         });
-      }, Math.round(Math.random() * 1000));
+      }, Math.round(Math.random() * 500));
     });
 
     return compiler;

--- a/packages/flex-plugin-webpack/src/compiler.ts
+++ b/packages/flex-plugin-webpack/src/compiler.ts
@@ -130,7 +130,7 @@ export default (
           appName: getPaths().app.name,
           lastPluginBundle: config.plugins.length === config.loadedPlugins.length,
         });
-      }, Math.round(Math.random() * 500));
+      }, Math.round(Math.random() * 1000));
     });
 
     return compiler;

--- a/packages/flex-plugin-webpack/src/devServer/__tests__/pluginServer.test.ts
+++ b/packages/flex-plugin-webpack/src/devServer/__tests__/pluginServer.test.ts
@@ -1,3 +1,6 @@
+import https from 'https';
+import Stream from 'stream';
+
 import * as fsScript from '@twilio/flex-dev-utils/dist/fs';
 import { Request, Response } from 'express-serve-static-core';
 import { FlexPluginError } from '@twilio/flex-dev-utils';
@@ -22,6 +25,28 @@ describe('pluginServer', () => {
     version: '1.2.3',
     dependencies: {},
     devDependencies: {},
+  };
+
+  const getReqResp = (
+    method: string,
+    headers: Record<string, string>,
+    cookies: Record<string, string> = {},
+    url?: string,
+  ) => {
+    // @ts-ignore
+    const resp = {
+      writeHead: jest.fn(),
+      end: jest.fn(),
+    } as Response;
+    const req = {
+      method,
+      headers,
+      cookies,
+      url,
+    } as Request;
+    const next = jest.fn();
+
+    return { req, resp, next };
   };
 
   beforeEach(() => {
@@ -99,6 +124,57 @@ describe('pluginServer', () => {
     });
   });
 
+  describe('_makeRequestToFlex', () => {
+    it('should return data returned from Flex', async () => {
+      const streamStream = new Stream();
+      // @ts-ignore
+      const httpSpy = jest.spyOn(https, 'request').mockImplementation((_url, cb) => {
+        // @ts-ignore
+        // eslint-disable-next-line callback-return
+        cb(streamStream);
+
+        streamStream.emit('data', Buffer.from('some'));
+        streamStream.emit('data', Buffer.from('-'));
+        streamStream.emit('data', Buffer.from('data'));
+
+        streamStream.emit('end');
+      });
+
+      const data = await pluginServerScript._makeRequestToFlex('jwe-token', '/dummy-path');
+
+      expect(httpSpy).toHaveBeenCalledWith(
+        {
+          hostname: 'flex.twilio.com',
+          port: 443,
+          path: '/dummy-path',
+          method: 'GET',
+          headers: {
+            'X-Flex-JWE': 'jwe-token',
+          },
+        },
+        expect.any(Function),
+      );
+      expect(data).toBe('some-data');
+    });
+
+    it('should error if the request to Flex fails', async () => {
+      const streamStream = new Stream();
+      // @ts-ignore
+      jest.spyOn(https, 'request').mockImplementation((_url, cb) => {
+        // @ts-ignore
+        // eslint-disable-next-line callback-return
+        cb(streamStream);
+        streamStream.emit('error', 'some-error');
+      });
+
+      try {
+        await pluginServerScript._makeRequestToFlex('jwe-token', '/dummy-path');
+      } catch (e) {
+        expect(e.message).toContain('some-error');
+      }
+    });
+  });
+
   describe('_mergePlugins', () => {
     it('should return both remote and local plugins', () => {
       const localPlugin = { name: defaultPluginName, phase: 3 } as pluginServerScript.Plugin;
@@ -163,32 +239,7 @@ describe('pluginServer', () => {
     });
   });
 
-  describe('_startServer', () => {
-    const port = 9000;
-    const plugins = {
-      local: ['plugin-local1', 'plugin-local2'],
-      remote: ['plugin-remote1', 'plugin-remote2'],
-      versioned: ['plugin-remote2'],
-    };
-    const config = { port, remoteAll: true };
-    const jweHeaders = { 'x-flex-jwe': 'jweToken' };
-    const getReqResp = (method: string, headers: Record<string, string>, cookies: Record<string, string> = {}) => {
-      // @ts-ignore
-      const resp = {
-        writeHead: jest.fn(),
-        end: jest.fn(),
-      } as Response;
-      const req = {
-        method,
-        headers,
-        cookies,
-      } as Request;
-      const next = jest.fn();
-
-      return { req, resp, next };
-    };
-    const onRemotePlugins = jest.fn();
-
+  describe('_requestValidator', () => {
     it('should return 200 for OPTIONS request', async () => {
       const { req, resp, next } = getReqResp('OPTIONS', {});
       const _getHeaders = jest.spyOn(pluginServerScript, '_getHeaders').mockReturnValue({ header: 'true' });
@@ -222,6 +273,66 @@ describe('pluginServer', () => {
       expect(resp.writeHead).toHaveBeenCalledWith(400, { header: 'true' });
       expect(resp.end).toHaveBeenCalledTimes(1);
     });
+  });
+
+  describe('_renderPluginServer', () => {
+    const headers = {};
+    const cookies = {
+      'flex-jwe': 'jweToken',
+    };
+    const pluginPath = '/plugin-sample/1.0.0/bundle.js';
+
+    it('should render plugin content', async (done) => {
+      const { req, resp } = getReqResp('GET', headers, cookies, pluginPath);
+      const remotePluginContent = 'dummy-source-code-of-the-plugin';
+
+      jest.spyOn(pluginServerScript, '_getHeaders').mockReturnValue({ header: 'true' });
+      const _getPluginContent = jest
+        .spyOn(pluginServerScript, '_makeRequestToFlex')
+        .mockResolvedValue(remotePluginContent);
+
+      await pluginServerScript._renderPluginServer(req, resp);
+
+      expect(resp.writeHead).toHaveBeenCalledTimes(1);
+      expect(resp.writeHead).toHaveBeenCalledWith(200, {
+        header: 'true',
+      });
+      expect(_getPluginContent).toHaveBeenCalledTimes(1);
+      expect(_getPluginContent).toHaveBeenCalledWith(cookies['flex-jwe'], `/plugins/v1${pluginPath}`);
+      expect(resp.end).toHaveBeenCalledTimes(1);
+      expect(resp.end).toHaveBeenCalledWith(remotePluginContent);
+      done();
+    });
+
+    it('should 500 in case of errors', async () => {
+      const { req, resp } = getReqResp('GET', headers, cookies, pluginPath);
+
+      jest.spyOn(pluginServerScript, '_getHeaders').mockReturnValue({ header: 'true' });
+      const _getPluginContent = jest
+        .spyOn(pluginServerScript, '_makeRequestToFlex')
+        .mockRejectedValue('failed-message');
+
+      await pluginServerScript._renderPluginServer(req, resp);
+
+      expect(resp.writeHead).toHaveBeenCalledTimes(1);
+      expect(resp.writeHead).toHaveBeenCalledWith(500, { header: 'true' });
+      expect(_getPluginContent).toHaveBeenCalledTimes(1);
+      expect(_getPluginContent).toHaveBeenCalledWith(cookies['flex-jwe'], `/plugins/v1${pluginPath}`);
+      expect(resp.end).toHaveBeenCalledTimes(1);
+      expect(resp.end).toHaveBeenCalledWith('failed-message');
+    });
+  });
+
+  describe('_fetchPluginsServer', () => {
+    const port = 9000;
+    const plugins = {
+      local: ['plugin-local1', 'plugin-local2'],
+      remote: ['plugin-remote1', 'plugin-remote2'],
+      versioned: ['plugin-remote2'],
+    };
+    const config = { port, remoteAll: true };
+    const jweHeaders = { 'x-flex-jwe': 'jweToken' };
+    const onRemotePlugins = jest.fn();
 
     it('should getPlugins and rebase', async (done) => {
       const { req, resp } = getReqResp('GET', jweHeaders);

--- a/packages/flex-plugin-webpack/src/devServer/pluginServer.ts
+++ b/packages/flex-plugin-webpack/src/devServer/pluginServer.ts
@@ -273,7 +273,7 @@ export const _fetchPluginsServer = (
 /**
  * Basic server to fetch plugin bundle content from Flex and return to the local dev-server
  */
-const _renderPluginServer = async (req: Request, res: Response): Promise<void> => {
+export const _renderPluginServer = async (req: Request, res: Response): Promise<void> => {
   const jweToken = req.cookies['flex-jwe'] as string;
   const responseHeaders = _getHeaders();
 


### PR DESCRIPTION
--include-remote flag in flex:plugins:start command is broken as a side-effect of the fix released for the third-party cookie phase-out by Google Chrome. Since 3rd party cookies are going to be blocked by default, Flex is now using partitioned cookies for authentication. In localhost, partitioned cookies are inaccessible hence, the remote plugins were failing to load.

With this fix, the remote plugins will be loaded via webpack dev server middleware which will call Flex endpoint by authenticating the request using the X-Flex-JWE header.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
