### PR TITLE
Added support for logging without markdown

### DIFF
--- a/packages/flex-dev-utils/src/logger/lib/__tests__/logger.test.ts
+++ b/packages/flex-dev-utils/src/logger/lib/__tests__/logger.test.ts
@@ -119,6 +119,18 @@ describe('logger', () => {
     expect(info).toHaveBeenCalledWith('var1 var2');
   });
 
+  it('should log without markdown', () => {
+    // @ts-ignore
+    const logSpy = jest.spyOn(_logger, '_log');
+    logger.log('var1', 'var2');
+
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith('var1 var2');
+    expect(logSpy).toHaveBeenCalledWith({ level: 'info', markdown: false, args: ['var1', 'var2'] });
+
+    logSpy.mockRestore();
+  });
+
   it('should print single entry column', () => {
     logger.columns([['one-entry']]);
 

--- a/packages/flex-dev-utils/src/logger/lib/logger.ts
+++ b/packages/flex-dev-utils/src/logger/lib/logger.ts
@@ -22,6 +22,7 @@ export type LogLevels = 'debug' | 'info' | 'warning' | 'error' | 'trace' | 'succ
 interface LogArg {
   color?: Color;
   level: Level;
+  markdown?: boolean;
   args: string[];
 }
 
@@ -130,6 +131,14 @@ export class Logger {
   constructor(options?: LoggerOptions) {
     this.options = options || {};
   }
+
+  /**
+   * simple log without markdown
+   * @param args
+   */
+  public log = (...args: any[]): void => {
+    this._log({ level: 'info', markdown: false, args });
+  };
 
   /**
    * debug level log
@@ -303,7 +312,11 @@ export class Logger {
       const color = args.color ? chalk[args.color] : (msg: string) => msg;
       const msg = format.apply({}, args.args as any);
 
-      pipe(msg, color, this.markdown, log);
+      if (Boolean(args.markdown)) {
+        pipe(msg, color, this.markdown, log);
+      } else {
+        pipe(msg, color, log);
+      }
     }
   };
 
@@ -354,8 +367,21 @@ const wrap = (input: string, columns: number, options = DefaultWrapOptions): str
  * You can create an instance to overwrite default behavior.
  */
 export const _logger = new Logger();
-const { debug, info, warning, error, trace, success, newline, notice, installInfo, clearTerminal, markdown, columns } =
-  _logger;
+const {
+  log,
+  debug,
+  info,
+  warning,
+  error,
+  trace,
+  success,
+  newline,
+  notice,
+  installInfo,
+  clearTerminal,
+  markdown,
+  columns,
+} = _logger;
 
 export default {
   debug,
@@ -374,4 +400,5 @@ export default {
   colors: chalk,
   coloredStrings,
   linkText,
+  log,
 };

--- a/packages/flex-plugin-scripts/src/prints/validateSuccessful.ts
+++ b/packages/flex-plugin-scripts/src/prints/validateSuccessful.ts
@@ -20,22 +20,22 @@ const printWarnings = (issues: Warning[]): void => {
 
       if (line !== undefined && column !== undefined) {
         logger.newline();
-        logger.info(logger.coloredStrings.link(logger.coloredStrings.underline(`${file}:${line}:${column + 1}`)));
+        logger.log(logger.coloredStrings.link(logger.coloredStrings.underline(`${file}:${line}:${column + 1}`)));
       }
 
       logger.newline();
-      logger.info(`${logger.coloredStrings.warning('Warning:')} ${warningMessage}`);
+      logger.log(`${logger.coloredStrings.warning('Warning:')} ${warningMessage}`);
 
       if (message) {
         logger.newline();
-        logger.info(`${logger.coloredStrings.success('Recommendation:')} ${message}`);
+        logger.log(`${logger.coloredStrings.success('Recommendation:')} ${message}`);
         if (code) {
           logger.newline();
-          logger.info(logger.coloredStrings.code(code));
+          logger.log(logger.coloredStrings.code(code));
         }
         if (link) {
           logger.newline();
-          logger.info(`More details ${logger.coloredStrings.bold(logger.linkText('here', link))}`);
+          logger.log(`More details ${logger.coloredStrings.bold(logger.linkText('here', link))}`);
         }
       }
     }


### PR DESCRIPTION
Added support for logging without markdown and used the new `log` method in validation report logs.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
