### PR TITLE
Validate error message handling and test coverage improvement

### DIFF
--- a/packages/flex-plugin-scripts/src/scripts/validate.ts
+++ b/packages/flex-plugin-scripts/src/scripts/validate.ts
@@ -123,7 +123,9 @@ const validate = async (
     if (e?.code === ETIMEDOUT) {
       logger.error('Plugin validation timed out. Note: This may be an enterprise firewall issue');
     } else {
-      logger.error(`Validation of plugin ${pkgName} failed`);
+      const errorResponse = e.response?.data?.message;
+      const errorMessage = errorResponse ? `${errorResponse}\n\n` : '';
+      logger.error(`${errorMessage}Validation of plugin ${pkgName} failed`);
     }
     throw new TwilioCliError();
   }

--- a/packages/plugin-flex/package.json
+++ b/packages/plugin-flex/package.json
@@ -119,7 +119,7 @@
           "changelog": "The changes (added/removed) made in this plugin version.",
           "description": "The description of this Flex plugin.",
           "option": "Option to automatically pick post validation of the plugin.",
-          "bypass-validation": "Publishes the plugin even if validation step identifies issues in the plugin."
+          "bypass-validation": "Validates the plugin and continues to plugin deployment ignoring validation issues, if any."
         }
       },
       "flex:plugins:create-configuration": {

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/archive/configuration.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/archive/configuration.test.ts
@@ -51,4 +51,10 @@ describe('Commands/Archive/FlexPluginsArchiveConfiguration', () => {
     expect(cmd.getResourceType()).toContain('Flex');
     expect(cmd.getResourceType()).toContain('Configuration');
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createCmd();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsArchiveConfiguration.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/archive/plugin-version.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/archive/plugin-version.test.ts
@@ -335,4 +335,10 @@ describe('Commands/Archive/FlexPluginsArchivePluginVersion', () => {
     expect(cmd.getResourceType()).toContain('Flex');
     expect(cmd.getResourceType()).toContain('Plugin Version');
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createCmd();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsArchivePluginVersion.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/archive/plugin.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/archive/plugin.test.ts
@@ -256,4 +256,10 @@ describe('Commands/Archive/FlexPluginsArchivePlugin', () => {
     expect(cmd.getResourceType()).toContain('Flex');
     expect(cmd.getResourceType()).toContain('Plugin');
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createCmd();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsArchivePlugin.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/build.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/build.test.ts
@@ -35,4 +35,10 @@ describe('Build2', () => {
 
     expect(cmd.checkCompatibility).toEqual(true);
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createTest(FlexPluginsBuild)();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsBuild.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/create-configuration.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/create-configuration.test.ts
@@ -1,11 +1,17 @@
 import FlexPluginsCreateConfiguration from '../../../../commands/flex/plugins/create-configuration';
 import CreateConfiguration from '../../../../sub-commands/create-configuration';
 import FlexPlugin from '../../../../sub-commands/flex-plugin';
-import '../../../framework';
+import createTest from '../../../framework';
 
 describe('Commands/FlexPluginsCreateConfiguration', () => {
   it('should have own flags', () => {
     expect(FlexPluginsCreateConfiguration.flags).not.toBeSameObject(CreateConfiguration.flags);
     expect(FlexPluginsCreateConfiguration.flags).not.toBeSameObject(FlexPlugin.flags);
+  });
+
+  it('should get topic name', async () => {
+    const cmd = await createTest(FlexPluginsCreateConfiguration)();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsCreateConfiguration.topicName);
   });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/deploy.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/deploy.test.ts
@@ -678,4 +678,10 @@ describe('Commands/FlexPluginsDeploy', () => {
 
     expect(getCredential).toHaveBeenCalledTimes(0);
   });
+
+  it('should get topic name', async () => {
+    const cmd = await getCommand();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsDeploy.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/describe/configuration.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/describe/configuration.test.ts
@@ -49,4 +49,10 @@ describe('Commands/Describe/FlexPluginsDescribeConfiguration', () => {
     expect(cmd.pluginsApiToolkit.describeConfiguration).toHaveBeenCalledTimes(1);
     expect(cmd.pluginsApiToolkit.describeConfiguration).toHaveBeenCalledWith({ sid: configuration.sid });
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createCommand('--sid', configuration.sid);
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsDescribeConfiguration.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/describe/plugin-version.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/describe/plugin-version.test.ts
@@ -16,4 +16,10 @@ describe('Commands/Describe/FlexPluginsDescribePluginVersion', () => {
     await cmd.init();
     expect(cmd._flags).toBeDefined();
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createTest(FlexPluginsDescribePluginVersion)('--name', 'plugin-one', '--version', '1.0.2');
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsDescribePluginVersion.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/describe/plugin.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/describe/plugin.test.ts
@@ -16,4 +16,10 @@ describe('Commands/Describe/FlexPluginsDescribePlugin', () => {
     await cmd.init();
     expect(cmd._flags).toBeDefined();
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createTest(FlexPluginsDescribePlugin)('--name', 'plugin-one');
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsDescribePlugin.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/describe/release.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/describe/release.test.ts
@@ -22,4 +22,10 @@ describe('Commands/Describe/FlexPluginsDescribeRelease', () => {
     const cmd = await createCommand('--sid', sid);
     expect(cmd._flags).toBeDefined();
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createCommand('--sid', sid);
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsDescribeRelease.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/diff.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/diff.test.ts
@@ -96,4 +96,10 @@ describe('Commands/FlexPluginsDeploy', () => {
     expect(cmd.printDiff).toHaveBeenCalledWith(diffs.plugins['plugin-added'][0], prefix);
     expect(cmd.printDiff).toHaveBeenCalledWith(diffs.plugins['plugin-deleted'][0], prefix);
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createCommand(configId1, configId2);
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsDiff.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/list/configurations.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/list/configurations.test.ts
@@ -1,11 +1,17 @@
 import FlexPluginsListConfigurations from '../../../../../commands/flex/plugins/list/configurations';
 import FlexPlugin from '../../../../../sub-commands/flex-plugin';
 import InformationFlexPlugin from '../../../../../sub-commands/information-flex-plugin';
-import '../../../../framework';
+import createTest from '../../../../framework';
 
 describe('Commands/List/FlexPluginsListConfigurations', () => {
   it('should have own flags', () => {
     expect(FlexPluginsListConfigurations.flags).not.toBeSameObject(InformationFlexPlugin.flags);
     expect(FlexPluginsListConfigurations.flags).not.toBeSameObject(FlexPlugin.flags);
+  });
+
+  it('should get topic name', async () => {
+    const cmd = await createTest(FlexPluginsListConfigurations)();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsListConfigurations.topicName);
   });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/list/plugin-versions.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/list/plugin-versions.test.ts
@@ -16,4 +16,10 @@ describe('Commands/List/FlexPluginsListPluginVersions', () => {
     await cmd.init();
     expect(cmd._flags).toBeDefined();
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createTest(FlexPluginsListPluginVersions)('--name', 'plugin-one');
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsListPluginVersions.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/list/plugins.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/list/plugins.test.ts
@@ -1,11 +1,17 @@
 import FlexPluginsListPlugins from '../../../../../commands/flex/plugins/list/plugins';
 import FlexPlugin from '../../../../../sub-commands/flex-plugin';
 import InformationFlexPlugin from '../../../../../sub-commands/information-flex-plugin';
-import '../../../../framework';
+import createTest from '../../../../framework';
 
 describe('Commands/List/FlexPluginsListPlugins', () => {
   it('should have own flags', () => {
     expect(FlexPluginsListPlugins.flags).not.toBeSameObject(InformationFlexPlugin.flags);
     expect(FlexPluginsListPlugins.flags).not.toBeSameObject(FlexPlugin.flags);
+  });
+
+  it('should get topic name', async () => {
+    const cmd = await createTest(FlexPluginsListPlugins)();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsListPlugins.topicName);
   });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/list/releases.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/list/releases.test.ts
@@ -1,11 +1,17 @@
 import FlexPluginsListPlugins from '../../../../../commands/flex/plugins/list/releases';
 import FlexPlugin from '../../../../../sub-commands/flex-plugin';
 import InformationFlexPlugin from '../../../../../sub-commands/information-flex-plugin';
-import '../../../../framework';
+import createTest from '../../../../framework';
 
 describe('Commands/List/FlexPluginsListPlugins', () => {
   it('should have own flags', () => {
     expect(FlexPluginsListPlugins.flags).not.toBeSameObject(InformationFlexPlugin.flags);
     expect(FlexPluginsListPlugins.flags).not.toBeSameObject(FlexPlugin.flags);
+  });
+
+  it('should get topic name', async () => {
+    const cmd = await createTest(FlexPluginsListPlugins)();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsListPlugins.topicName);
   });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/release.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/release.test.ts
@@ -47,4 +47,10 @@ describe('Commands/FlexPluginsRelease', () => {
       expect(e).toBeInstanceOf(RequiredFlagError);
     }
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createTest(FlexPluginsRelease)('--configuration-sid', configurationSid);
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsRelease.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/start.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/start.test.ts
@@ -528,4 +528,10 @@ describe('Commands/FlexPluginsStart', () => {
     expect(get).toHaveBeenCalledTimes(1);
     expect(get).toHaveBeenCalledWith(name, goodVersion);
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createCommand('--name', pluginNameOne);
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsStart.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/test.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/test.test.ts
@@ -46,4 +46,10 @@ describe('Commands/FlexPluginsTest', () => {
 
     expect(cmd.checkCompatibility).toEqual(true);
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createCommand();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsTest.topicName);
+  });
 });

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/upgrade-plugin.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/upgrade-plugin.test.ts
@@ -60,6 +60,12 @@ describe('Commands/FlexPluginsStart', () => {
     expect(cmd._flags).toBeDefined();
   });
 
+  it('should get topic name', async () => {
+    const cmd = await createCommand();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsUpgradePlugin.topicName);
+  });
+
   it('should should return then version of @twilio/flex-plugin-scripts from dependencies', async () => {
     const cmd = await createCommand();
 

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/validate.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/validate.test.ts
@@ -32,4 +32,10 @@ describe('Validate', () => {
     const cmd = await createCommand();
     expect(cmd.checkCompatibility).toEqual(true);
   });
+
+  it('should get topic name', async () => {
+    const cmd = await createCommand();
+
+    expect(cmd.getTopicName()).toContain(FlexPluginsValidate.topicName);
+  });
 });

--- a/packages/plugin-flex/src/commands/flex/plugins/list/configurations.ts
+++ b/packages/plugin-flex/src/commands/flex/plugins/list/configurations.ts
@@ -45,4 +45,11 @@ export default class FlexPluginsListConfigurations extends InformationFlexPlugin
       this._logger.newline();
     });
   }
+
+  /**
+   * @override
+   */
+  getTopicName(): string {
+    return FlexPluginsListConfigurations.topicName;
+  }
 }


### PR DESCRIPTION
- Improved unit test patch coverage
- Capture and display validation error message, if present
- Updated --bypass-validation flag description

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
