### PR TITLE
FLEXY-5303 Token size issue when fetching remote plugins

### DIFF
--- a/packages/create-flex-plugin/templates/js2/package.json
+++ b/packages/create-flex-plugin/templates/js2/package.json
@@ -10,8 +10,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "prop-types": "^15.7.2",
-    "@twilio-paste/core": "^10.14.0",
-    "@twilio-paste/icons": "^5.7.0"
+    "@twilio-paste/core": "^^15.3.1",
+    "@twilio-paste/icons": "^^9.2.0"
   },
   "devDependencies": {
     "@twilio/flex-ui": "{{flexSdkVersion}}",

--- a/packages/create-flex-plugin/templates/js2/package.json
+++ b/packages/create-flex-plugin/templates/js2/package.json
@@ -10,8 +10,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "prop-types": "^15.7.2",
-    "@twilio-paste/core": "^^15.3.1",
-    "@twilio-paste/icons": "^^9.2.0"
+    "@twilio-paste/core": "^15.3.1",
+    "@twilio-paste/icons": "^9.2.0"
   },
   "devDependencies": {
     "@twilio/flex-ui": "{{flexSdkVersion}}",

--- a/packages/create-flex-plugin/templates/ts2/package.json
+++ b/packages/create-flex-plugin/templates/ts2/package.json
@@ -10,8 +10,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "prop-types": "^15.7.2",
-    "@twilio-paste/core": "^10.14.0",
-    "@twilio-paste/icons": "^5.7.0"
+    "@twilio-paste/core": "^^15.3.1",
+    "@twilio-paste/icons": "^^9.2.0"
   },
   "devDependencies": {
     "@twilio/flex-ui": "{{flexSdkVersion}}",

--- a/packages/create-flex-plugin/templates/ts2/package.json
+++ b/packages/create-flex-plugin/templates/ts2/package.json
@@ -10,8 +10,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "prop-types": "^15.7.2",
-    "@twilio-paste/core": "^^15.3.1",
-    "@twilio-paste/icons": "^^9.2.0"
+    "@twilio-paste/core": "^15.3.1",
+    "@twilio-paste/icons": "^9.2.0"
   },
   "devDependencies": {
     "@twilio/flex-ui": "{{flexSdkVersion}}",

--- a/packages/flex-plugin-webpack/src/devServer/__tests__/pluginServer.test.ts
+++ b/packages/flex-plugin-webpack/src/devServer/__tests__/pluginServer.test.ts
@@ -359,6 +359,7 @@ describe('pluginServer', () => {
     };
     const config = { port, remoteAll: true };
     const jweHeaders = { 'x-flex-jwe': 'jweToken' };
+    const jweHeadersLargeToken = { 'x-flex-jwe': 't'.repeat(4000) };
     const onRemotePlugins = jest.fn();
 
     it('should getPlugins and rebase', async () => {
@@ -386,6 +387,46 @@ describe('pluginServer', () => {
       });
       expect(_getRemotePlugins).toHaveBeenCalledTimes(1);
       expect(_getRemotePlugins).toHaveBeenCalledWith('jweToken', '/plugins', undefined);
+      expect(_getRemoteVersionedPlugins).toHaveBeenCalledTimes(1);
+      expect(_getRemoteVersionedPlugins).toHaveBeenCalledWith(plugins.versioned);
+      expect(_mergePlugins).toHaveBeenCalledTimes(1);
+      expect(onRemotePlugins).toHaveBeenCalledTimes(1);
+      expect(onRemotePlugins).toHaveBeenCalledWith(remotePlugin);
+      expect(resp.end).toHaveBeenCalledTimes(1);
+      expect(resp.end).toHaveBeenCalledWith('[{"name":"plugin-1"},{"name":"plugin-2"}]');
+    });
+
+    it('should getPlugins and rebase even if token size has increased', async () => {
+      const { req, resp } = getReqResp('GET', jweHeadersLargeToken);
+      const remotePlugin = [{ name: 'plugin-2', phase: 3 }] as pluginServerScript.Plugin[];
+
+      jest.spyOn(pluginServerScript, '_getHeaders').mockReturnValue({ header: 'true' });
+      const _getRemotePlugins = jest
+        .spyOn(pluginServerScript, '_makeRequestToFlex')
+        .mockResolvedValue(JSON.stringify(remotePlugin));
+      const _getRemoteVersionedPlugins = jest
+        .spyOn(pluginServerScript, '_getRemoteVersionedPlugins')
+        .mockReturnValue([]);
+      const _mergePlugins = jest
+        .spyOn(pluginServerScript, '_mergePlugins')
+        .mockReturnValue([{ name: 'plugin-1' }, { name: 'plugin-2' }] as pluginServerScript.Plugin[]);
+      jest.spyOn(fsScript, 'readPluginsJson').mockReturnValue({ plugins: [{ name: 'plugin-1', dir: pluginDir }] });
+
+      await pluginServerScript._fetchPluginsServer(plugins, config, onRemotePlugins)(req, resp);
+
+      expect(resp.writeHead).toHaveBeenCalledTimes(1);
+      const flexJwe = 't'.repeat(pluginServerScript.JWE_TOKEN_LIMIT);
+      const flexJwe2 = 't'.repeat(100);
+      expect(resp.writeHead).toHaveBeenCalledWith(200, {
+        header: 'true',
+        'Set-Cookie': [`flex-jwe=${flexJwe};`, `flex-jwe-2=${flexJwe2};`],
+      });
+      expect(_getRemotePlugins).toHaveBeenCalledTimes(1);
+      expect(_getRemotePlugins).toHaveBeenCalledWith(
+        't'.repeat(pluginServerScript.JWE_TOKEN_LIMIT + 100),
+        '/plugins',
+        undefined,
+      );
       expect(_getRemoteVersionedPlugins).toHaveBeenCalledTimes(1);
       expect(_getRemoteVersionedPlugins).toHaveBeenCalledWith(plugins.versioned);
       expect(_mergePlugins).toHaveBeenCalledTimes(1);

--- a/packages/flex-plugin-webpack/src/devServer/__tests__/pluginServer.test.ts
+++ b/packages/flex-plugin-webpack/src/devServer/__tests__/pluginServer.test.ts
@@ -352,7 +352,7 @@ describe('pluginServer', () => {
       expect(resp.writeHead).toHaveBeenCalledTimes(1);
       expect(resp.writeHead).toHaveBeenCalledWith(200, {
         header: 'true',
-        'Set-Cookie': `flex-jwe=${jweHeaders['x-flex-jwe']}`,
+        'Set-Cookie': [`flex-jwe=${jweHeaders['x-flex-jwe']}`],
       });
       expect(_getRemotePlugins).toHaveBeenCalledTimes(1);
       expect(_getRemotePlugins).toHaveBeenCalledWith('jweToken', '/plugins', undefined);

--- a/packages/flex-plugin-webpack/src/devServer/__tests__/pluginServer.test.ts
+++ b/packages/flex-plugin-webpack/src/devServer/__tests__/pluginServer.test.ts
@@ -122,6 +122,36 @@ describe('pluginServer', () => {
     });
   });
 
+  describe('splitTokenToChunks', () => {
+    const token = 't'.repeat(4000);
+
+    it('should return splitted tokens', () => {
+      const result = pluginServerScript.splitTokenToChunks(token, pluginServerScript.JWE_TOKEN_LIMIT);
+      expect(result).toEqual(['t'.repeat(pluginServerScript.JWE_TOKEN_LIMIT), 't'.repeat(100)]);
+    });
+
+    it('should throw error', () => {
+      try {
+        pluginServerScript.splitTokenToChunks(token, -1);
+      } catch (e) {
+        expect(e).toBeInstanceOf(FlexPluginError);
+        expect(e.message).toContain('Token chunks Length must be a positive integer');
+      }
+    });
+  });
+
+  describe('combineJweToken', () => {
+    const tokenChunks = {
+      'flex-jwe': 't'.repeat(pluginServerScript.JWE_TOKEN_LIMIT),
+      'flex-jwe-2': 't'.repeat(100),
+    };
+
+    it('should return combined token', () => {
+      const result = pluginServerScript.combineJweToken(tokenChunks);
+      expect(result).toEqual('t'.repeat(pluginServerScript.JWE_TOKEN_LIMIT + 100));
+    });
+  });
+
   describe('_makeRequestToFlex', () => {
     it('should return data returned from Flex', async () => {
       const streamStream = new Stream();

--- a/packages/flex-plugin-webpack/src/devServer/pluginServer.ts
+++ b/packages/flex-plugin-webpack/src/devServer/pluginServer.ts
@@ -171,18 +171,18 @@ export const _makeRequestToFlex = async (token: string, path: string, version?: 
   });
 };
 
-const splitTokenToChunks = (str: string, length: number): string[] => {
+const splitTokenToChunks = (token: string, length: number): string[] => {
   if (length <= 0) {
     throw new Error('Length must be a positive integer');
   }
 
-  const chunks: string[] = [];
-  for (let i = 0; i < str.length; i += length) {
-    const chunk = str.slice(i, i + length);
-    chunks.push(chunk);
+  const tokenChunks: string[] = [];
+  for (let i = 0; i < token.length; i += length) {
+    const chunk = token.slice(i, i + length);
+    tokenChunks.push(chunk);
   }
 
-  return chunks;
+  return tokenChunks;
 };
 
 const combineJweToken = (cookies: { [key: string]: string }): string => {

--- a/packages/flex-plugin-webpack/src/devServer/pluginServer.ts
+++ b/packages/flex-plugin-webpack/src/devServer/pluginServer.ts
@@ -305,7 +305,7 @@ export const _fetchPluginsServer = (
           onRemotePlugin([...versionedPlugins, ...remotePlugins]);
           let cookiesToSet = [`flex-jwe=${jweToken}`];
           if (jweToken.length > JWE_TOKEN_LIMIT) {
-            const jweTokenChunks = splitTokenToChunks(jweToken, 3900);
+            const jweTokenChunks = splitTokenToChunks(jweToken, JWE_TOKEN_LIMIT);
             logger.debug(
               `The JWE token is too long (${jweToken.length} characters). It will be split into ${jweTokenChunks.length} chunks.`,
             );

--- a/packages/plugin-flex/src/__tests__/commands/flex/plugins/deploy.test.ts
+++ b/packages/plugin-flex/src/__tests__/commands/flex/plugins/deploy.test.ts
@@ -37,7 +37,7 @@ describe('Commands/FlexPluginsDeploy', () => {
     accountSid: 'AC00000000000000000000000000000',
     environmentSid: 'ZE00000000000000000000000000000',
     domainName: 'ruby-fox-123.twil.io',
-    CliVersion: '6.4.1',
+    CliVersion: '7.0.0',
     isPublic: false,
     nextVersion: '2.0.0',
     pluginUrl: 'https://ruby-fox-123.twil.io/plugin-url',


### PR DESCRIPTION
The --include-remote did not work when token size increased beyond browser limit failing the plugins load. This PR fixes that

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
