### PR TITLE
remove deprecated version of `actions/upload-artifact: v3`

### DIFF
--- a/.github/workflows/~reusable_e2e_by_OS.yaml
+++ b/.github/workflows/~reusable_e2e_by_OS.yaml
@@ -192,7 +192,7 @@ jobs:
           cd packages/flex-plugin-e2e-tests
           npm run start
       - name: Upload Screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ inputs.OS }}-screenshots


### PR DESCRIPTION
E2E nightly failing with Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
