### PR TITLE
Fix E2E test timeout by caching Puppeteer binaries

### DIFF
--- a/.github/workflows/~reusable_e2e_by_OS.yaml
+++ b/.github/workflows/~reusable_e2e_by_OS.yaml
@@ -102,6 +102,22 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.NODE_VERSION }}
+      - name: Get Puppeteer cache directory
+        id: puppeteer-cache-dir
+        run: |
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            echo "dir=$HOME/.cache/puppeteer" >> $GITHUB_OUTPUT
+          else
+            echo "dir=$(echo ~/.cache/puppeteer)" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+      - name: Cache Puppeteer binaries
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.puppeteer-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-puppeteer-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-puppeteer-
       - name: Override localhost to IPv4 in Linux for Node 18
         run: |
           sudo sed -i '/localhost/s/::1/#::1/' /etc/hosts
@@ -109,17 +125,17 @@ jobs:
       - name: Install project dependencies (Linux)
         if: ${{ inputs.OS == 'ubuntu-22.04' }}
         run: |
-          echo "Starting npm ci with a 10-minute timeout"
+          echo "Starting npm ci with a 15-minute timeout"
           for i in 1 2 3; do # Retry logic, retry 3 times
-            timeout 10m npm ci --verbose && break || echo "npm ci failed, retrying ($i/3)..."
+            timeout 15m npm ci --verbose && break || echo "npm ci failed, retrying ($i/3)..."
           done
       - name: Install project dependencies (Macos)
         if: ${{ inputs.OS == 'macos-latest' }}
         run: |
-          echo "Starting npm ci with a 10-minute timeout"
+          echo "Starting npm ci with a 15-minute timeout"
           brew install coreutils
           for i in 1 2 3; do # Retry logic, retry 3 times
-            gtimeout 10m npm ci --verbose && break || echo "npm ci failed, retrying ($i/3)..."
+            gtimeout 15m npm ci --verbose && break || echo "npm ci failed, retrying ($i/3)..."
           done
       - name: Install project dependencies (Windows)
         if: ${{ inputs.OS == 'windows-latest' }}


### PR DESCRIPTION
## Summary

Fixes intermittent E2E nightly test failures caused by Puppeteer Chrome binary download timing out during `npm ci`.

## Changes

- **Add Puppeteer binary caching**: Cache `~/.cache/puppeteer` directory between workflow runs
- **Increase timeout**: Bump npm ci timeout from 10m to 15m for Linux and macOS
- **Smart cache invalidation**: Cache key based on `package-lock.json` hash

## Problem

The E2E nightly tests were failing intermittently on macOS (and occasionally Linux) with:
```
npm error signal SIGTERM
npm error command sh -c node install.mjs
```

The `gtimeout 10m npm ci` command was killing the process after 10 minutes while Puppeteer was downloading Chrome binaries (~200MB).

## Solution

By caching the Puppeteer binaries, subsequent runs will skip the download entirely (cache hit) or only download if dependencies change. Combined with the increased timeout, this should eliminate the intermittent failures.

## Test Plan

- [x] Changes tested locally
- [ ] Wait for next scheduled E2E run to verify cache behavior
- [ ] Monitor success rate over next few days

🤖 Generated with [Claude Code](https://claude.com/claude-code)